### PR TITLE
build: add llvm_update_compile_flags and mlir_check_all_link_libraries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,5 +3,7 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 set(gc_opt_libs ${dialect_libs} ${conversion_libs} MLIROptLib)
 add_llvm_executable(gc-opt gc-opt.cpp)
 target_link_libraries(gc-opt PRIVATE ${gc_opt_libs})
+llvm_update_compile_flags(gc-opt)
+mlir_check_all_link_libraries(gc-opt)
 
 add_subdirectory(dnnl)


### PR DESCRIPTION
Add calls to `llvm_update_compile_flags` and `mlir_check_all_link_libraries` for `gc-opt`, as MLIR upstream does for mlir's own executable targets.