### PR TITLE
Copy llvm-lit to the llvm installation

### DIFF
--- a/.github/workflows/build-llvm.yml
+++ b/.github/workflows/build-llvm.yml
@@ -28,6 +28,7 @@ jobs:
           cmake -G Ninja llvm -B build -DCMAKE_INSTALL_PREFIX=llvm-install \
             -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=true -DLLVM_ENABLE_PROJECTS="mlir" -DLLVM_TARGETS_TO_BUILD="X86" -DLLVM_INSTALL_UTILS=true -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           cmake --build build --target install
+          cp llvm/bin/llvm-lit llvm-install/bin
           cd llvm-install
           tar -zcf ../llvm.tgz .
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-.*/
+.vscode/
 build/
 compile_commands.json


### PR DESCRIPTION
A bit hacky, but lits are not a part of the llvm installation in any way. We could tar the build itself, but it's larger. Thoughts?