### PR TITLE
Implement a version getter for the graph compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(GraphCompiler LANGUAGES C CXX)
-
+project(GraphCompiler VERSION "0.1.0" LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -42,6 +41,8 @@ set(GC_LIB_SOURCES CACHE INTERNAL "The graph_compiler library source paths")
 set(GC_LIB_INCLUDES CACHE INTERNAL "The graph_compiler library include paths")
 
 add_definitions(${LLVM_DEFINITIONS})
+include("cmake/version.cmake")
+
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(src)

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,25 @@
+include_guard()
+
+string(REPLACE "." ";" VERSION_LIST ${PROJECT_VERSION})
+list(GET VERSION_LIST 0 GC_VERSION_MAJOR)
+list(GET VERSION_LIST 1 GC_VERSION_MINOR)
+list(GET VERSION_LIST 2 GC_VERSION_PATCH)
+
+find_package(Git)
+if(GIT_FOUND)
+    execute_process(COMMAND ${GIT_EXECUTABLE} -c log.showSignature=false log --no-abbrev-commit --oneline -1 --format=%H
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE GC_VERSION_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
+if(NOT GIT_FOUND OR RESULT)
+    set(GC_VERSION_HASH "N/A")
+endif()
+
+add_compile_definitions(
+    GC_VERSION_MAJOR=${GC_VERSION_MAJOR}
+    GC_VERSION_MINOR=${GC_VERSION_MINOR}
+    GC_VERSION_PATCH=${GC_VERSION_PATCH}
+    GC_VERSION_HASH="${GC_VERSION_HASH}")

--- a/include/gc_version.h
+++ b/include/gc_version.h
@@ -1,0 +1,15 @@
+#ifndef GC_VERSION_H
+#define GC_VERSION_H
+
+#if !defined(GC_VERSION_MAJOR) || !defined(GC_VERSION_MINOR) || !defined(GC_VERSION_PATCH)
+// define an invalid version if it wasn't defined by CMake
+#include <limits>
+#define GC_VERSION_MAJOR std::numeric_limits<uint8_t>::max()
+#define GC_VERSION_MINOR std::numeric_limits<uint8_t>::max()
+#define GC_VERSION_PATCH std::numeric_limits<uint8_t>::max()
+#endif
+#ifndef GC_VERSION_HASH
+#define GC_VERSION_HASH "N/A"
+#endif
+
+#endif

--- a/src/dnnl/dnnl_graph_compiler.cpp
+++ b/src/dnnl/dnnl_graph_compiler.cpp
@@ -1,8 +1,20 @@
 #include "dnnl_graph_compiler.hpp"
+#include "gc_version.h"
 #include <new>
 
 // dnnl_graph_compiler.h interface implementation.
-// TODO: Implement
+// TODO: Implement.
+
+const dnnl_graph_compiler_version *dnnl_graph_compiler_get_version(void) {
+  static const dnnl_graph_compiler_version ver = {
+      .api_version = {DNNL_GC_API_V_MAJOR, DNNL_GC_API_V_MINOR,
+                      DNNL_GC_API_V_PATCH,
+                      DNNL_GC_API_V_HASH}, // version defined by oneDNN
+      .gc_version = {
+          GC_VERSION_MAJOR, GC_VERSION_MINOR, GC_VERSION_PATCH,
+          GC_VERSION_HASH}}; // version defined by graph compiler itself
+  return &ver;
+}
 
 dnnl_status_t
 dnnl_graph_compiler_create(const struct dnnl_graph_compiler_context *ctx,

--- a/test/dnnl/test_dnnl_c_interface.cpp
+++ b/test/dnnl/test_dnnl_c_interface.cpp
@@ -1,5 +1,6 @@
 #include "dnnl_graph_compiler.h"
 #include "dnnl_test_utils.hpp"
+#include "gc_version.h"
 #include <gtest/gtest.h>
 
 TEST(dnnl_graph_compiler, c_interface) {
@@ -27,6 +28,27 @@ TEST(dnnl_graph_compiler, c_interface) {
 
   dnnl_graph_compiler_destroy_executable(gc, exe);
   dnnl_graph_compiler_destroy(gc);
+}
+
+TEST(dnnl_graph_compiler, get_version) {
+  auto v = dnnl_graph_compiler_get_version();
+
+  ASSERT_NE(v, nullptr);
+
+  ASSERT_EQ(v->api_version.major, DNNL_GC_API_V_MAJOR);
+  ASSERT_EQ(v->api_version.minor, DNNL_GC_API_V_MINOR);
+  ASSERT_EQ(v->api_version.patch, DNNL_GC_API_V_PATCH);
+  ASSERT_STREQ(v->api_version.hash, DNNL_GC_API_V_HASH);
+
+  // check if the version is valid
+  ASSERT_NE(v->gc_version.major, std::numeric_limits<uint8_t>::max());
+  ASSERT_NE(v->gc_version.minor, std::numeric_limits<uint8_t>::max());
+  ASSERT_NE(v->gc_version.patch, std::numeric_limits<uint8_t>::max());
+
+  ASSERT_EQ(v->gc_version.major, GC_VERSION_MAJOR);
+  ASSERT_EQ(v->gc_version.minor, GC_VERSION_MINOR);
+  ASSERT_EQ(v->gc_version.patch, GC_VERSION_PATCH);
+  ASSERT_STREQ(v->gc_version.hash, GC_VERSION_HASH);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Align with the GC API changes made in https://github.com/kurapov-peter/oneDNN/pull/1 (implemented a getter function for GC version `dnnl_graph_compiler_get_version`)