### PR TITLE
[Transform] add bf16 / fp16 promotion pass

### DIFF
--- a/include/gc/Transforms/LegalizeUtils.h
+++ b/include/gc/Transforms/LegalizeUtils.h
@@ -1,0 +1,36 @@
+//===- LegalizeUtils.h - Utils for LegalizeDtypeToF32 Pass ------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LEGALIZE_UTILS_H
+#define LEGALIZE_UTILS_H
+
+#include "mlir/Pass/Pass.h"
+#include <memory>
+
+namespace mlir {
+class ConversionTarget;
+class RewritePatternSet;
+class TypeConverter;
+
+namespace gc {
+
+struct CPUFlags {
+  bool fAVX512FP16 = true;
+};
+template <typename T>
+void populateLegalizeDTypeToF32TypeConverter(TypeConverter &typeConverter);
+void populateBfloat16ToF32ConversionTarget(ConversionTarget &target,
+                                           TypeConverter &typeConverter);
+void populateFloat16ToF32ConversionTarget(ConversionTarget &target,
+                                          TypeConverter &typeConverter);
+void populateLegalizeDTypeToF32Patterns(RewritePatternSet &patterns,
+                                        TypeConverter &typeConverter);
+} // namespace gc
+} // namespace mlir
+
+#endif

--- a/include/gc/Transforms/Passes.td
+++ b/include/gc/Transforms/Passes.td
@@ -17,4 +17,21 @@ def TileLinalgNamed : Pass<"tile-named-linalg", "func::FuncOp"> {
       ["linalg::LinalgDialect", "scf::SCFDialect", "tensor::TensorDialect"];
 }
 
+def LegalizeDTypeToF32 : Pass<"legalizedtype-to-f32"> {
+  let summary = "Legalize floating-point math ops on low-precision floats";
+  let description = [{
+    On many targets, the math functions are not implemented for floating-point
+    types less precise than IEEE single-precision (aka f32), such as half-floats
+    or bfloat16.
+
+    This pass explicitly legalizes these math functions by inserting
+    `arith.extf` and `arith.truncf` pairs around said op, which preserves
+    the original semantics while enabling lowering.
+
+    This pass awares target machine flags. If fAVX512FP16 is true, then some ops
+    has no need to do the legalization.
+  }];
+  let dependentDialects = ["mlir::math::MathDialect", "mlir::arith::ArithDialect"];
+}
+
 #endif // GC_DIALECT_GC_PASSES

--- a/lib/gc/Transforms/CMakeLists.txt
+++ b/lib/gc/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(GCPasses
   TileNamed.cpp
+  LegalizeDtypeToF32.cpp
 
   ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include

--- a/lib/gc/Transforms/LegalizeDtypeToF32.cpp
+++ b/lib/gc/Transforms/LegalizeDtypeToF32.cpp
@@ -1,0 +1,153 @@
+//===- LegalizeDtypeToF32.cpp - Promote low-precision to f32 ----*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/TypeUtilities.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/STLExtras.h"
+
+#include "gc/Transforms/LegalizeUtils.h"
+#include "gc/Transforms/Passes.h"
+namespace mlir {
+namespace gc {
+#define GEN_PASS_DEF_LEGALIZEDTYPETOF32
+#include "gc/Transforms/Passes.h.inc"
+CPUFlags cpuf;
+} // namespace gc
+
+struct LegalizeToF32RewritePattern final : ConversionPattern {
+  LegalizeToF32RewritePattern(TypeConverter &converter, MLIRContext *context)
+      : ConversionPattern(converter, MatchAnyOpTypeTag{}, 1, context) {}
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> operands,
+                  ConversionPatternRewriter &rewriter) const override;
+};
+
+LogicalResult LegalizeToF32RewritePattern::matchAndRewrite(
+    Operation *op, ArrayRef<Value> operands,
+    ConversionPatternRewriter &rewriter) const {
+  Location loc = op->getLoc();
+  const TypeConverter *converter = getTypeConverter();
+  FailureOr<Operation *> legalized =
+      convertOpResultTypes(op, operands, *converter, rewriter);
+  if (failed(legalized))
+    return failure();
+
+  SmallVector<Value> results = (*legalized)->getResults();
+  for (auto [result, newType, origType] : llvm::zip_equal(
+           results, (*legalized)->getResultTypes(), op->getResultTypes())) {
+    if (newType != origType)
+      result = rewriter.create<arith::TruncFOp>(loc, origType, result);
+  }
+  rewriter.replaceOp(op, results);
+  return success();
+}
+
+namespace gc {
+template <typename T>
+void populateLegalizeToF32TypeConverter(TypeConverter &typeConverter) {
+  typeConverter.addConversion(
+      [](Type type) -> std::optional<Type> { return type; });
+  typeConverter.addConversion([](FloatType type) -> std::optional<Type> {
+    if (isa<T>(type))
+      return Float32Type::get(type.getContext());
+    return std::nullopt;
+  });
+  typeConverter.addConversion([](ShapedType type) -> std::optional<Type> {
+    if (auto elemTy = dyn_cast<T>(type.getElementType()))
+      return type.clone(Float32Type::get(type.getContext()));
+    return std::nullopt;
+  });
+  typeConverter.addTargetMaterialization(
+      [](OpBuilder &b, Type target, ValueRange input, Location loc) {
+        return b.create<arith::ExtFOp>(loc, target, input);
+      });
+}
+
+void populateBfloat16ToF32ConversionTarget(ConversionTarget &target,
+                                           TypeConverter &typeConverter) {
+  target.addDynamicallyLegalDialect<mlir::math::MathDialect>(
+      [&typeConverter](Operation *op) -> bool {
+        return typeConverter.isLegal(op);
+      });
+  target.addDynamicallyLegalOp<
+      arith::AddFOp, arith::SubFOp, arith::MulFOp, arith::DivFOp,
+      arith::MaximumFOp, arith::MinimumFOp, arith::CmpFOp, arith::SelectOp>(
+      [&typeConverter](Operation *op) -> bool {
+        return typeConverter.isLegal(op);
+      });
+  target.addLegalOp<arith::ExtFOp, arith::TruncFOp>();
+}
+
+void populateFloat16ToF32ConversionTarget(ConversionTarget &target,
+                                          TypeConverter &typeConverter) {
+  target.addDynamicallyLegalDialect<mlir::math::MathDialect>(
+      [&typeConverter](Operation *op) -> bool {
+        return typeConverter.isLegal(op);
+      });
+  if (!cpuf.fAVX512FP16)
+    target.addDynamicallyLegalOp<
+        arith::AddFOp, arith::SubFOp, arith::MulFOp, arith::DivFOp,
+        arith::MaximumFOp, arith::MinimumFOp, arith::CmpFOp, arith::SelectOp>(
+        [&typeConverter](Operation *op) -> bool {
+          return typeConverter.isLegal(op);
+        });
+  else
+    target.addLegalOp<math::AbsFOp, math::CeilOp, math::FloorOp, math::RoundOp,
+                      math::SqrtOp, math::RsqrtOp, math::Exp2Op>();
+  target.addLegalOp<arith::ExtFOp, arith::TruncFOp>();
+}
+
+void populateLegalizeToF32Patterns(RewritePatternSet &patterns,
+                                   TypeConverter &typeConverter) {
+  patterns.add<LegalizeToF32RewritePattern>(typeConverter,
+                                            patterns.getContext());
+}
+
+class LegalizeDTypeToF32
+    : public impl::LegalizeDTypeToF32Base<LegalizeDTypeToF32> {
+public:
+  using impl::LegalizeDTypeToF32Base<
+      LegalizeDTypeToF32>::LegalizeDTypeToF32Base;
+  void runOnOperation() final;
+};
+
+void LegalizeDTypeToF32::runOnOperation() {
+  Operation *op = getOperation();
+  MLIRContext &ctx = getContext();
+
+  // for bf16 legalization
+  {
+    TypeConverter bf16Converter;
+    populateLegalizeToF32TypeConverter<BFloat16Type>(bf16Converter);
+    ConversionTarget target(ctx);
+    populateBfloat16ToF32ConversionTarget(target, bf16Converter);
+    RewritePatternSet patterns(&ctx);
+    populateLegalizeToF32Patterns(patterns, bf16Converter);
+    if (failed(applyPartialConversion(op, target, std::move(patterns))))
+      return signalPassFailure();
+  }
+
+  // for fp16 legalization
+  {
+    TypeConverter f16Converter;
+    populateLegalizeToF32TypeConverter<Float16Type>(f16Converter);
+    ConversionTarget target(ctx);
+    populateFloat16ToF32ConversionTarget(target, f16Converter);
+    RewritePatternSet patterns(&ctx);
+    populateLegalizeToF32Patterns(patterns, f16Converter);
+    if (failed(applyPartialConversion(op, target, std::move(patterns))))
+      return signalPassFailure();
+  }
+}
+
+} // namespace gc
+} // namespace mlir

--- a/test/gc-transforms/legalizedtype-to-f32.mlir
+++ b/test/gc-transforms/legalizedtype-to-f32.mlir
@@ -1,0 +1,129 @@
+// RUN: gc-opt %s --split-input-file --legalizedtype-to-f32 | FileCheck %s
+
+// CHECK-LABEL: @sin_bf16
+// CHECK-SAME: ([[ARG0:%.+]]: bf16)
+func.func @sin_bf16(%arg0: bf16) -> bf16 {
+  // CHECK: [[EXTF:%.+]] = arith.extf [[ARG0]]
+  // CHECK: [[SIN:%.+]] = math.sin [[EXTF]]
+  // CHECK: [[TRUNCF:%.+]] = arith.truncf [[SIN]]
+  // CHECK: return [[TRUNCF]] : bf16
+  %0 = math.sin %arg0 : bf16
+  return %0 : bf16
+}
+
+// CHECK-LABEL: @sin_f16
+// CHECK-SAME: ([[ARG0:%.+]]: f16)
+func.func @sin_f16(%arg0: f16) -> f16 {
+  // CHECK: [[EXTF:%.+]] = arith.extf [[ARG0]]
+  // CHECK: [[SIN:%.+]] = math.sin [[EXTF]]
+  // CHECK: [[TRUNCF:%.+]] = arith.truncf [[SIN]]
+  // CHECK: return [[TRUNCF]] : f16
+  %0 = math.sin %arg0 : f16
+  return %0 : f16
+}
+
+// CHECK-LABEL: @abs_bf16
+// CHECK-SAME: ([[ARG0:%.+]]: bf16)
+func.func @abs_bf16(%arg0: bf16) -> bf16 {
+  // CHECK: [[EXTF:%.+]] = arith.extf [[ARG0]]
+  // CHECK: [[ABS:%.+]] = math.absf [[EXTF]]
+  // CHECK: [[TRUNCF:%.+]] = arith.truncf [[ABS]]
+  // CHECK: return [[TRUNCF]] : bf16
+  %0 = math.absf %arg0 : bf16
+  return %0 : bf16
+}
+
+// COM: Verify that the pass leaves `math.absf` with `float16` untouched, since the default
+// COM: cpuflags.fAVX512FP16 is true. 
+// COM: May change this test case when target machine desciption is ready.
+// CHECK-LABEL: @abs_f16
+// CHECK-SAME: ([[ARG0:%.+]]: f16)
+func.func @abs_f16(%arg0: f16) -> f16 {
+  // CHECK: [[ABS:%.+]] = math.absf [[ARG0]]
+  // CHECK: return [[ABS]] : f16
+  %0 = math.absf %arg0 : f16
+  return %0 : f16
+}
+
+// CHECK-LABEL: @fma_bf16
+// CHECK-SAME: ([[ARG0:%.+]]: bf16, [[ARG1:%.+]]: bf16, [[ARG2:%.+]]: bf16)
+// CHECK: [[EXTF0:%.+]] = arith.extf [[ARG0]]
+// CHECK: [[EXTF1:%.+]] = arith.extf [[ARG1]]
+// CHECK: [[EXTF2:%.+]] = arith.extf [[ARG2]]
+// CHECK: [[FMA:%.+]] = math.fma [[EXTF0]], [[EXTF1]], [[EXTF2]]
+// CHECK: [[TRUNCF:%.+]] = arith.truncf [[FMA]]
+// CHECK: return [[TRUNCF]] : bf16
+func.func @fma_bf16(%arg0: bf16, %arg1: bf16, %arg2: bf16) -> bf16 {
+  %0 = math.fma %arg0, %arg1, %arg2 : bf16
+  return %0 : bf16
+}
+
+// CHECK-LABEL: @fma_f16
+// CHECK-SAME: ([[ARG0:%.+]]: f16, [[ARG1:%.+]]: f16, [[ARG2:%.+]]: f16)
+// CHECK: [[EXTF0:%.+]] = arith.extf [[ARG0]]
+// CHECK: [[EXTF1:%.+]] = arith.extf [[ARG1]]
+// CHECK: [[EXTF2:%.+]] = arith.extf [[ARG2]]
+// CHECK: [[FMA:%.+]] = math.fma [[EXTF0]], [[EXTF1]], [[EXTF2]]
+// CHECK: [[TRUNCF:%.+]] = arith.truncf [[FMA]]
+// CHECK: return [[TRUNCF]] : f16
+func.func @fma_f16(%arg0: f16, %arg1: f16, %arg2: f16) -> f16 {
+  %0 = math.fma %arg0, %arg1, %arg2 : f16
+  return %0 : f16
+}
+
+// CHECK-LABEL: @absf_f64
+// CHECK-SAME: ([[ARG0:%.+]]: f64)
+// CHECK: [[ABSF:%.+]] = math.absf [[ARG0]]
+// CHECK: return [[ABSF]] : f64
+func.func @absf_f64(%arg0: f64) -> f64 {
+  %0 = math.absf %arg0 : f64
+  return %0 : f64
+}
+
+// CHECK-LABEL: @sin_vector
+// CHECK-SAME: ([[ARG0:%.+]]: vector<2xbf16>)
+// CHECK: [[EXTF:%.+]] = arith.extf [[ARG0]]
+// CHECK: [[SIN:%.+]] = math.sin [[EXTF]]
+// CHECK: [[TRUNCF:%.+]] = arith.truncf [[SIN]]
+// CHECK: return [[TRUNCF]] : vector<2xbf16>
+func.func @sin_vector(%arg0: vector<2xbf16>) -> vector<2xbf16> {
+  %0 = math.sin %arg0 : vector<2xbf16>
+  return %0 : vector<2xbf16>
+}
+
+// CHECK-LABEL: @abs_vector
+// CHECK-SAME: ([[ARG0:%.+]]: vector<2xf16>)
+// CHECK: [[ABS:%.+]] = math.absf [[ARG0]]
+// CHECK: return [[ABS]] : vector<2xf16>
+func.func @abs_vector(%arg0: vector<2xf16>) -> vector<2xf16> {
+  %0 = math.absf %arg0 : vector<2xf16>
+  return %0 : vector<2xf16>
+}
+
+// CHECK-LABEL: @sequences_bf16
+// CHECK-SAME: ([[ARG0:%.+]]: bf16)
+// CHECK: [[EXTF0:%.+]] = arith.extf [[ARG0]]
+// CHECK: [[ABSF:%.+]] = math.absf [[EXTF0]]
+// CHECK: [[TRUNCF0:%.+]] = arith.truncf [[ABSF]]
+// CHECK: [[EXTF1:%.+]] = arith.extf [[TRUNCF0]]
+// CHECK: [[SIN:%.+]] = math.sin [[EXTF1]]
+// CHECK: [[TRUNCF1:%.+]] = arith.truncf [[SIN]]
+// CHECK: return [[TRUNCF1]] : bf16
+func.func @sequences_bf16(%arg0: bf16) -> bf16 {
+  %0 = math.absf %arg0 : bf16
+  %1 = math.sin %0 : bf16
+  return %1 : bf16
+}
+
+// CHECK-LABEL: @sequences_f16
+// CHECK-SAME: ([[ARG0:%.+]]: f16)
+// CHECK: [[ABSF:%.+]] = math.absf [[ARG0]]
+// CHECK: [[EXTF1:%.+]] = arith.extf [[ABSF]]
+// CHECK: [[SIN:%.+]] = math.sin [[EXTF1]]
+// CHECK: [[TRUNCF1:%.+]] = arith.truncf [[SIN]]
+// CHECK: return [[TRUNCF1]] : f16
+func.func @sequences_f16(%arg0: f16) -> f16 {
+  %0 = math.absf %arg0 : f16
+  %1 = math.sin %0 : f16
+  return %1 : f16
+}


### PR DESCRIPTION
Tracking: #59 

This PR implements bf16 / fp16 promotion pass.
A temporary `CPUFlags` struct is included, indicating the needed target machine info for this pass.

The [`paired type cast elimination` PR](https://github.com/crazydemo/llvm-project/pull/1/files) is under review, and will be upstreamed to the MLIR community.