### PR TITLE
[GC-API] Align with the current GC API

### DIFF
--- a/test/dnnl/test_dnnl_c_interface.cpp
+++ b/test/dnnl/test_dnnl_c_interface.cpp
@@ -18,7 +18,7 @@ TEST(dnnl_graph_compiler, c_interface) {
   dnnl_graph_compiler_tensor inputs[2];
   dnnl_graph_compiler_tensor outputs[1];
   uint8_t data_buf[160];
-  size_t dims[1] = {10};
+  int64_t dims[1] = {10};
   inputs[0] = {.id = 0, .ndims = 1, .dims = dims, .data = data_buf};
   inputs[1] = {.id = 1, .ndims = 1, .dims = dims, .data = &data_buf[40]};
   outputs[0] = {.id = 2, .ndims = 1, .dims = dims, .data = &data_buf[80]};


### PR DESCRIPTION
Align with the GC API changes introduced in https://github.com/kurapov-peter/oneDNN/pull/2

In `dnnl_graph_compiler_tensor` the `dims` field was changed from `size_t*` to `int64_t*`.