### PR TITLE
[Transforms] Add constant_weights_folding pass

### DIFF
--- a/include/gc/Analysis/DataFlow/ConstantSubgraphAnalysis.h
+++ b/include/gc/Analysis/DataFlow/ConstantSubgraphAnalysis.h
@@ -1,0 +1,127 @@
+//===- ConstantSubgraphAnalysis.h - Constant subgraph analysis ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements constant subgraph analysis. In this file are:
+// 1. the lattice value class that represents operations with constant inputs
+// and outputs in the program, and
+// 2. a sparse constant subgraph analysis.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_ANALYSIS_DATAFLOW_CONSTANTSUBGRAPHANALYSIS_H
+#define MLIR_ANALYSIS_DATAFLOW_CONSTANTSUBGRAPHANALYSIS_H
+
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include <optional>
+
+namespace mlir {
+namespace dataflow {
+
+//===----------------------------------------------------------------------===//
+// InConstantSubgraph
+//===----------------------------------------------------------------------===//
+
+/// This lattice represents a boolean integer indicating if an operation is with
+/// constant inputs and constant outputs and hence in constant subgraph.
+class InConstantSubgraph {
+public:
+  /// Construct as uninitialized.
+  explicit InConstantSubgraph() = default;
+
+  /// Construct with a known state.
+  explicit InConstantSubgraph(bool initialized, bool inConstantSubgraph)
+      : initialized(initialized), inConstantSubgraph(inConstantSubgraph) {}
+
+  /// Get the state. Returns null if no value was determined.
+  bool getInConstantSubgraph() const {
+    assert(!isUninitialized());
+    return inConstantSubgraph;
+  }
+
+  /// Compare.
+  bool operator==(const InConstantSubgraph &rhs) const {
+    return initialized == rhs.initialized &&
+           inConstantSubgraph == rhs.inConstantSubgraph;
+  }
+
+  void print(raw_ostream &os) const;
+
+  /// Get uninitialized state. This happens when the
+  /// state hasn't been set during the analysis.
+  static InConstantSubgraph getUninitialized() { return InConstantSubgraph{}; }
+
+  /// Whether the state is uninitialized.
+  bool isUninitialized() const { return !initialized; }
+
+  /// Get unknown state.
+  static InConstantSubgraph getUnknown() {
+    return InConstantSubgraph{/*initialized=*/false,
+                              /*inConstantSubgraph=*/false};
+  }
+
+  // Join two states.
+  static InConstantSubgraph join(const InConstantSubgraph &lhs,
+                                 const InConstantSubgraph &rhs) {
+    // if one is uninitialized, use another
+    if (lhs.isUninitialized())
+      return rhs;
+    if (rhs.isUninitialized())
+      return lhs;
+
+    // both are initialized, intersect them
+    if (!lhs.isUninitialized() && !rhs.isUninitialized()) {
+      return InConstantSubgraph(true, lhs.getInConstantSubgraph() &&
+                                          rhs.getInConstantSubgraph());
+    }
+    return getUninitialized();
+  }
+
+private:
+  bool initialized = false;
+  bool inConstantSubgraph = false;
+};
+
+//===----------------------------------------------------------------------===//
+// ConstantSubgraphAnalysis
+//===----------------------------------------------------------------------===//
+
+class ConstantSubgraphAnalysis
+    : public SparseForwardDataFlowAnalysis<Lattice<InConstantSubgraph>> {
+public:
+  using SparseForwardDataFlowAnalysis::SparseForwardDataFlowAnalysis;
+
+  void visitOperation(Operation *op,
+                      ArrayRef<const Lattice<InConstantSubgraph> *> operands,
+                      ArrayRef<Lattice<InConstantSubgraph> *> results) override;
+
+  void setToEntryState(Lattice<InConstantSubgraph> *lattice) override;
+};
+
+//===----------------------------------------------------------------------===//
+// RunConstantSubgraphAnalysis
+//===----------------------------------------------------------------------===//
+
+/// Runs constant subgraph analysis on the IR defined by `op`.
+struct RunConstantSubgraphAnalysis {
+public:
+  RunConstantSubgraphAnalysis();
+
+  void run(Operation *op);
+
+  bool getInConstantSubgraph(Value val);
+
+private:
+  /// Stores the result of the analysis.
+  DataFlowSolver solver;
+
+  void getConstantSubgraph(DataFlowSolver &solver, Operation *topFunc);
+};
+} // end namespace dataflow
+} // end namespace mlir
+
+#endif // MLIR_ANALYSIS_DATAFLOW_CONSTANTSUBGRAPHANALYSIS_H

--- a/include/gc/Dialect/OnednnGraph/OnednnGraphDialect.td
+++ b/include/gc/Dialect/OnednnGraph/OnednnGraphDialect.td
@@ -24,6 +24,7 @@ def OnednnGraphDialect : Dialect {
     let cppNamespace = "::mlir::onednn_graph";
 
     let useDefaultTypePrinterParser = 1;
+    let hasOperationAttrVerify = 1;
 }
 
 #endif // ONEDNNGRAPH_DIALECT

--- a/include/gc/Transforms/Passes.h
+++ b/include/gc/Transforms/Passes.h
@@ -15,7 +15,12 @@ namespace mlir {
 namespace gc {
 
 #define GEN_PASS_DECL
+#define GEN_PASS_DECL_CSA
+#define GEN_PASS_DECL_CST
 #include "gc/Transforms/Passes.h.inc"
+
+std::unique_ptr<Pass> createCSAPass();
+std::unique_ptr<Pass> createCSTPass();
 
 #define GEN_PASS_REGISTRATION
 #include "gc/Transforms/Passes.h.inc"

--- a/include/gc/Transforms/Passes.td
+++ b/include/gc/Transforms/Passes.td
@@ -17,4 +17,20 @@ def TileLinalgNamed : Pass<"tile-named-linalg", "func::FuncOp"> {
       ["linalg::LinalgDialect", "scf::SCFDialect", "tensor::TensorDialect"];
 }
 
+def CSA : Pass<"csa"> {
+  let summary = "Constant Subgraph Analysis";
+  let description = [{
+    This pass implements a constant subgraph analysis.
+  }];
+  let constructor = "mlir::gc::createCSAPass()";
+}
+
+def CST : Pass<"cst"> {
+  let summary = "Constant Subgraph Transform";
+  let description = [{
+    This pass implements a constant subgraph transform.
+  }];
+  let constructor = "mlir::gc::createCSTPass()";
+}
+
 #endif // GC_DIALECT_GC_PASSES

--- a/lib/gc/Analysis/CMakeLists.txt
+++ b/lib/gc/Analysis/CMakeLists.txt
@@ -1,10 +1,8 @@
-add_mlir_library(GCPasses
-  TileNamed.cpp
-  CSA.cpp
-  CST.cpp
+add_mlir_library(GCAnalysis
+  DataFlow/ConstantSubgraphAnalysis.cpp
 
   ADDITIONAL_HEADER_DIRS
-    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include/
 
   DEPENDS
     GraphCompilerPassIncGen

--- a/lib/gc/Analysis/DataFlow/ConstantSubgraphAnalysis.cpp
+++ b/lib/gc/Analysis/DataFlow/ConstantSubgraphAnalysis.cpp
@@ -1,0 +1,180 @@
+//===- ConstantSubgraphAnalysis.cpp - Constant subgraph analysis ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include "gc/Analysis/DataFlow/ConstantSubgraphAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include <cassert>
+
+#define DEBUG_TYPE "in-constant-subgraph"
+
+using namespace mlir;
+using namespace mlir::dataflow;
+
+//===----------------------------------------------------------------------===//
+// InConstantSubgraph
+//===----------------------------------------------------------------------===//
+
+void InConstantSubgraph::print(raw_ostream &os) const {
+  if (isUninitialized()) {
+    os << "<UNINITIALIZED>";
+    return;
+  }
+  os << getInConstantSubgraph();
+  return;
+}
+
+//===----------------------------------------------------------------------===//
+// ConstantSubgraphAnalysis
+//===----------------------------------------------------------------------===//
+
+void ConstantSubgraphAnalysis::visitOperation(
+    Operation *op, ArrayRef<const Lattice<InConstantSubgraph> *> operands,
+    ArrayRef<Lattice<InConstantSubgraph> *> results) {
+  LLVM_DEBUG(llvm::dbgs() << "ConstantSubgraphAnalysis: Visiting operation:\n"
+                          << *op << "\n");
+
+  bool in = true;
+  if (op->hasTrait<OpTrait::ConstantLike>()) {
+    LLVM_DEBUG(llvm::dbgs() << "Curr op is a Constant op\n");
+    in = true;
+  } else if (operands.size() == 0) { // For example, tensor.empty()
+    LLVM_DEBUG(llvm::dbgs() << "Curr op has 0 operand, constant\n");
+    in = true;
+  } else {
+    LLVM_DEBUG(llvm::dbgs() << "Curr op has " << operands.size()
+                            << " operands, check if constant\n");
+    for (auto *operandLattice : operands) {
+      auto operandState = operandLattice->getValue().getInConstantSubgraph();
+      LLVM_DEBUG(llvm::dbgs() << "Operand: " << operandLattice->getPoint()
+                              << ", lattice value: " << operandState << "\n");
+      if (!operandState) {
+        in = false;
+        break;
+      }
+    }
+  }
+
+  // lattice in results should be in unintialized state.
+  if (!in) {
+    LLVM_DEBUG(llvm::dbgs() << "Curr op not in constant subgraph\n");
+    for (auto lattice : results) {
+      propagateIfChanged(lattice,
+                         lattice->join(InConstantSubgraph(true, false)));
+    }
+  } else {
+    LLVM_DEBUG(llvm::dbgs() << "Curr op in constant subgraph\n");
+    for (auto lattice : results) {
+      propagateIfChanged(lattice,
+                         lattice->join(InConstantSubgraph(true, true)));
+    }
+  }
+}
+
+void ConstantSubgraphAnalysis::setToEntryState(
+    Lattice<InConstantSubgraph> *lattice) {
+  if (auto blockArg = cast<BlockArgument>(lattice->getPoint())) {
+    auto parent_op = blockArg.getParentBlock()->getParentOp();
+    auto parent_op_attr = parent_op->getAttrDictionary();
+    std::optional<NamedAttribute> const_args =
+        parent_op_attr.getNamed("onednn_graph.const_args");
+    if (const_args.has_value()) {
+      ArrayAttr const_args_indexes =
+          llvm::dyn_cast<ArrayAttr>(const_args->getValue());
+      for (auto id : const_args_indexes) {
+        auto idint = llvm::cast<IntegerAttr>(id).getInt();
+        if (blockArg.getArgNumber() == idint) {
+          LLVM_DEBUG(llvm::dbgs() << "Block argument: " << blockArg
+                                  << " is marked as constant\n");
+          propagateIfChanged(lattice,
+                             lattice->join(InConstantSubgraph(true, true)));
+          return;
+        }
+      }
+    }
+    propagateIfChanged(lattice, lattice->join(InConstantSubgraph(true, false)));
+  } else {
+    propagateIfChanged(lattice,
+                       lattice->join(InConstantSubgraph::getUninitialized()));
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// RunConstantSubgraphAnalysis
+//===----------------------------------------------------------------------===//
+
+/// Get the operations whose inputs and outputs are all constant values.
+/// These operations will be put into a seperate subgraph.
+void RunConstantSubgraphAnalysis::getConstantSubgraph(DataFlowSolver &solver,
+                                                      Operation *topFunc) {
+  OpBuilder builder(topFunc->getContext());
+  SmallVector<Operation *> constantOperations;
+
+  Block &block = topFunc->getRegions().front().getBlocks().front();
+  for (Operation &op : llvm::make_early_inc_range(block)) {
+    // If all the result values of a op are const, we mark this op as const.
+    bool resultsAllConstant = true;
+    if (op.getNumResults() == 0) {
+      continue;
+    }
+    for (Value res : op.getResults()) {
+      auto *lattice = solver.lookupState<Lattice<InConstantSubgraph>>(res);
+      if (!lattice || lattice->getValue().isUninitialized()) {
+        resultsAllConstant = false;
+        break;
+      }
+      const InConstantSubgraph &latticeValue = lattice->getValue();
+      if (!latticeValue.getInConstantSubgraph()) {
+        resultsAllConstant = false;
+        break;
+      }
+    }
+    if (resultsAllConstant) {
+      op.setAttr("onednn_graph.in_const_subgraph", builder.getBoolAttr(true));
+      constantOperations.push_back(&op);
+    }
+  }
+
+  if (constantOperations.empty()) {
+    return;
+  }
+}
+
+RunConstantSubgraphAnalysis::RunConstantSubgraphAnalysis() {
+  solver.load<DeadCodeAnalysis>();
+  solver.load<ConstantSubgraphAnalysis>();
+}
+
+void RunConstantSubgraphAnalysis::run(Operation *topFunc) {
+  if (failed(solver.initializeAndRun(topFunc))) {
+    return;
+  }
+  getConstantSubgraph(solver, topFunc);
+}
+
+bool RunConstantSubgraphAnalysis::getInConstantSubgraph(Value val) {
+  auto *lattice = solver.lookupState<Lattice<InConstantSubgraph>>(val);
+  const InConstantSubgraph &latticeValue = lattice->getValue();
+  return latticeValue.getInConstantSubgraph();
+}

--- a/lib/gc/CMakeLists.txt
+++ b/lib/gc/CMakeLists.txt
@@ -3,4 +3,5 @@ if(GC_MLIR_CXX_FLAGS)
 endif()
 
 add_subdirectory(Dialect)
+add_subdirectory(Analysis)
 add_subdirectory(Transforms)

--- a/lib/gc/Dialect/OnednnGraph/OnednnGraphDialect.cpp
+++ b/lib/gc/Dialect/OnednnGraph/OnednnGraphDialect.cpp
@@ -18,3 +18,9 @@ void OnednnGraphDialect::initialize() {
 #include "gc/Dialect/OnednnGraph/OnednnGraphOps.cpp.inc"
       >();
 }
+
+LogicalResult
+OnednnGraphDialect::verifyOperationAttribute(Operation *op,
+                                             NamedAttribute attr) {
+  return success();
+}

--- a/lib/gc/Transforms/CSA.cpp
+++ b/lib/gc/Transforms/CSA.cpp
@@ -1,0 +1,51 @@
+//===- CSA.cpp - Constant Subgraph Analysis -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transformation pass performs a constant subgraph analysis
+// in MLIR.
+//
+//===----------------------------------------------------------------------===//
+#include "gc/Analysis/DataFlow/ConstantSubgraphAnalysis.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+namespace gc {
+#define GEN_PASS_DEF_CSA
+#include "gc/Transforms/Passes.h.inc"
+} // namespace gc
+
+using namespace mlir;
+using namespace mlir::dataflow;
+
+namespace gc {
+
+struct CSA : public impl::CSABase<CSA> {
+  void runOnOperation() override;
+};
+
+void CSA::runOnOperation() {
+  Operation *op = getOperation();
+  auto &func =
+      op->getRegions().front().getBlocks().front().getOperations().front();
+
+  // Hard-code: set the #1 argument to be constant.
+  // OpBuilder builder(op->getContext());
+  // func.setAttr("onednn_graph.const_args",
+  //     builder.getI32ArrayAttr({1,2,3,4}));
+
+  RunConstantSubgraphAnalysis csa;
+  (void)csa.run(&func);
+}
+
+std::unique_ptr<Pass> createCSAPass() { return std::make_unique<CSA>(); }
+
+} // namespace gc
+} // namespace mlir

--- a/lib/gc/Transforms/CST.cpp
+++ b/lib/gc/Transforms/CST.cpp
@@ -1,0 +1,496 @@
+//===- CST.cpp - Constant Subgraph Transform -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This transformation pass performs a constant subgraph transform in MLIR.
+//
+//===----------------------------------------------------------------------===//
+
+#include <deque>
+#include <unordered_set>
+
+#include "mlir/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+namespace mlir {
+namespace gc {
+#define GEN_PASS_DEF_CST
+#include "gc/Transforms/Passes.h.inc"
+} // namespace gc
+
+using namespace mlir;
+
+namespace gc {
+
+struct CST : public impl::CSTBase<CST> {
+  void runOnOperation() override;
+};
+
+bool isInConstantSubgraph(Operation *op) {
+  auto opNamespace = op->getDialect()->getNamespace();
+  if (opNamespace == linalg::LinalgDialect::getDialectNamespace() ||
+      opNamespace == tensor::TensorDialect::getDialectNamespace() ||
+      opNamespace == arith::ArithDialect::getDialectNamespace()) {
+    if (op->getAttr("onednn_graph.in_const_subgraph")) {
+      return true;
+    }
+  }
+  return false;
+}
+
+int64_t getTensorSize(TensorType t) {
+  Type eleType = t.getElementType();
+  unsigned bitWidth = eleType.getIntOrFloatBitWidth() / 8; // bytes
+  ArrayRef<int64_t> shape = t.getShape();
+  int64_t size = bitWidth;
+  for (auto s : shape) {
+    size *= s;
+  }
+  return size;
+}
+
+bool canMoveBefore(Operation *op) {
+  if (op->getDialect()->getNamespace() ==
+      arith::ArithDialect::getDialectNamespace()) {
+    return true;
+  }
+
+  if (op->getDialect()->getNamespace() !=
+      linalg::LinalgDialect::getDialectNamespace()) {
+    return false;
+  }
+
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+
+  SmallVector<AffineMap> indexingMaps = linalgOp.getIndexingMapsArray();
+  for (auto &affineMap : indexingMaps) {
+    if (!affineMap.isIdentity()) {
+      return false;
+    }
+  }
+
+  SmallVector<utils::IteratorType> iterTypes = linalgOp.getIteratorTypesArray();
+  for (auto &iterType : iterTypes) {
+    if (iterType != utils::IteratorType::parallel) {
+      return false;
+    }
+  }
+
+  if (op->getNumOperands() > 1) {
+    // int64_t numInputs = linalgOp.getNumDpsInputs();
+    int64_t numInits = linalgOp.getNumDpsInits();
+    // definingOp of init should be tensor.empty()
+    for (int64_t i = 0; i < numInits; ++i) {
+      OpOperand *outOperand = linalgOp.getDpsInitOperand(i);
+      auto parentOp = outOperand->get().getDefiningOp();
+      if (!isa<tensor::EmptyOp>(parentOp)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+void postponeBroadcast(Block &block) {
+  // auto bcOps = block.getOps<linalg::BroadcastOp>();
+  // for (linalg::BroadcastOp bcOp : bcOps) {}
+  SmallVector<Operation *> constBcOps;
+  for (Operation &op : block.getOperations()) {
+    if (isa<linalg::BroadcastOp>(&op)) {
+      Operation *bcOp = &op;
+      if (isInConstantSubgraph(bcOp)) {
+        constBcOps.push_back(bcOp);
+      }
+    }
+  }
+
+  for (auto bcOp : constBcOps) {
+    // For topo v -> pack -> bc -> mul -> matmul, we transform
+    // it to v -> pack -> mul -> bc -> matmul, so that we can fold
+    // v -> pack -> mul. Note that we require the topo to be sequential
+    // and all the Values have exactly one user.
+
+    // go upwards to BlockArg
+    SmallVector<Operation *> prevOps;
+    Operation *currOp = bcOp;
+    while (true) {
+      if (currOp->getNumOperands() != 1) {
+        break;
+      }
+      Value operand = currOp->getOperand(0);
+      if (isa<BlockArgument>(operand)) {
+        break;
+      } else {
+        currOp = operand.getDefiningOp();
+        prevOps.push_back(currOp);
+      }
+    }
+
+    // go downwards to the last constant op
+    SmallVector<Operation *> postOps;
+    currOp = bcOp;
+    while (true) {
+      if (currOp->getNumResults() != 1 || !currOp->hasOneUse()) {
+        break;
+      }
+      Value input = currOp->getResult(0);
+      currOp = *(input.getUsers().begin());
+      Value output = currOp->getResult(0);
+      // NOTE: we require that input shape and output shape of curr op to be
+      // same. Operations from tensor dialect, like
+      // pack/unpack/concat/collapse_shape/expand_shape/reshape/pad, are not
+      // supported. So we simply restrict that currOp to be from arith or
+      // linalg.
+      if (!isa<TensorType>(input.getType()) ||
+          !isa<TensorType>(output.getType()) ||
+          dyn_cast<TensorType>(input.getType()).getShape() !=
+              dyn_cast<TensorType>(output.getType()).getShape() ||
+          !canMoveBefore(currOp)) {
+        break;
+      }
+      if (!isInConstantSubgraph(currOp)) {
+        break;
+      } else {
+        postOps.push_back(currOp);
+      }
+    }
+    if (postOps.empty()) {
+      continue;
+    }
+
+    // move bcOp after the last constant op
+    SmallVector<Operation *> newPostOps;
+    Value operand = static_cast<Value>(bcOp->getOperand(0));
+    ArrayRef<int64_t> shapeBeforeBc =
+        dyn_cast<TensorType>(operand.getType()).getShape();
+    size_t postOpId = 0;
+    for (Operation *postOp : postOps) {
+      SmallVector<Type> newOperandTypes;
+      for (auto oriType : postOp->getOperandTypes()) {
+        TensorType tt = dyn_cast<TensorType>(oriType);
+        newOperandTypes.push_back(
+            tt.cloneWith(shapeBeforeBc, tt.getElementType()));
+      }
+      SmallVector<Type> newResultTypes;
+      for (auto oriType : postOp->getResultTypes()) {
+        TensorType tt = dyn_cast<TensorType>(oriType);
+        newResultTypes.push_back(
+            tt.cloneWith(shapeBeforeBc, tt.getElementType()));
+      }
+      auto *newPostOp =
+          Operation::create(postOp->getLoc(), postOp->getName(), newResultTypes,
+                            postOp->getOperands(),
+                            /*postOp->getAttrDictionary()*/ std::nullopt,
+                            /*postOp->getPropertiesStorage()*/ nullptr,
+                            postOp->getSuccessors(), postOp->getNumRegions());
+      for (auto [oldRegion, newRegion] :
+           llvm::zip(postOp->getRegions(), newPostOp->getRegions())) {
+        newRegion.takeBody(oldRegion);
+      }
+
+      if (postOpId == 0) {
+        // Only the first post op needs to replace its operand. Others only
+        // needs to call postOp->replaceAllUsesWith(newPostOp->getResults()).
+        newPostOp->getOperand(0).replaceAllUsesWith(operand);
+      }
+      ++postOpId;
+
+      newPostOp->setAttr("onednn_graph.in_const_subgraph",
+                         postOp->getAttr("onednn_graph.in_const_subgraph"));
+      if (postOp->getDialect()->getNamespace() ==
+          linalg::LinalgDialect::getDialectNamespace()) {
+        newPostOp->setAttr("operandSegmentSizes",
+                           postOp->getAttr("operandSegmentSizes"));
+
+        OpBuilder builder(postOp->getContext());
+        size_t indexingMapsSize =
+            dyn_cast<linalg::LinalgOp>(postOp).getIndexingMapsArray().size();
+        unsigned rank = shapeBeforeBc.size();
+        SmallVector<AffineMap> indexingMaps(
+            indexingMapsSize, builder.getMultiDimIdentityMap(rank));
+        auto indexingMapsAttr = builder.getAffineMapArrayAttr(indexingMaps);
+        newPostOp->setAttr("indexing_maps", indexingMapsAttr);
+
+        SmallVector<utils::IteratorType> iterTypes =
+            dyn_cast<linalg::LinalgOp>(postOp).getIteratorTypesArray();
+        iterTypes.resize(rank);
+        auto iterTypesAttr =
+            builder.getArrayAttr(llvm::to_vector(llvm::map_range(
+                iterTypes, [&](utils::IteratorType iter) -> mlir::Attribute {
+                  return linalg::IteratorTypeAttr::get(builder.getContext(),
+                                                       iter);
+                })));
+        newPostOp->setAttr("iterator_types", iterTypesAttr);
+      } else {
+        // Ops from other dialects.
+      }
+
+      // Modify the outputOperands of postOp. Here we simply assume that the
+      // value is from tensor.empty().
+      if (postOp->getNumOperands() > 0) {
+        for (size_t i = 1; i < postOp->getNumOperands(); ++i) {
+          auto outOperand = postOp->getOperand(i);
+          outOperand.setType(newOperandTypes.front());
+        }
+      }
+
+      block.getOperations().push_back(newPostOp);
+      newPostOp->moveAfter(postOp);
+      newPostOps.push_back(newPostOp);
+      postOp->replaceAllUsesWith(newPostOp->getResults());
+
+      operand = static_cast<Value>(newPostOp->getResult(0));
+    }
+
+    auto nextOp = *(newPostOps.back()->getUsers().begin());
+    nextOp->getOperand(0).replaceAllUsesWith(bcOp->getResult(0));
+    bcOp->moveAfter(newPostOps.back());
+    bcOp->getOperand(0).replaceUsesWithIf(operand, [&](OpOperand &val) {
+      Operation *op = val.getOwner();
+      return op == bcOp;
+    });
+
+    for (auto it = postOps.rbegin(); it != postOps.rend(); ++it) {
+      (*it)->erase();
+    }
+  }
+}
+
+static constexpr int DATA_SIZE_EXPANDING_THRESHOLD = 8;
+
+// Operate on tensors. Create fold() and compute() on module. The
+// folded weights and first-run flag is maintained by upper-level runtime.
+void CST::runOnOperation() {
+  Operation *topOp = getOperation();
+  MLIRContext *context = topOp->getContext();
+  // A ModuleOp contains a single region, which contains a single block.
+  auto moduleOp = dyn_cast<ModuleOp>(topOp);
+  SymbolTable symbolTable(moduleOp);
+  auto &topFunc =
+      topOp->getRegions().front().getBlocks().front().getOperations().front();
+  OpBuilder builder(context);
+
+  auto topFuncAttr = topFunc.getAttrDictionary();
+  std::optional<NamedAttribute> constArgs =
+      topFuncAttr.getNamed("onednn_graph.const_args");
+  std::unordered_set<int> constArgsIndexes;
+  if (constArgs.has_value()) {
+    ArrayAttr constArgsArray = llvm::dyn_cast<ArrayAttr>(constArgs->getValue());
+    for (auto id : constArgsArray) {
+      constArgsIndexes.insert(llvm::cast<IntegerAttr>(id).getInt());
+    }
+  } else {
+    return;
+  }
+  if (constArgsIndexes.empty()) {
+    return;
+  }
+
+  Region &region = topFunc.getRegions().front();
+  Block &block = region.getBlocks().front();
+
+  postponeBroadcast(block);
+
+  SmallVector<Operation *> constOps;
+  for (Operation &op : llvm::make_early_inc_range(block)) {
+    if (isInConstantSubgraph(&op)) {
+      constOps.push_back(&op);
+    }
+  }
+
+  std::string funcName("fold");
+  SmallVector<Type> inputTypes; // types of constant weights
+  // values of constant weights in original block
+  SmallVector<Value> inputValues;
+  SmallVector<Type> outputTypes; // types of folded constant weights
+  // values of folded constant weights in original block
+  SmallVector<Value> outputValues;
+  Value v;
+  // TODO: solve complicated topology. Currently we only handle simple topology
+  // where one constant weight input will and only will produce one constant
+  // output and each constant weight only contributes to one constant output.
+  for (size_t id = 0; id < block.getNumArguments(); ++id) {
+    if (constArgsIndexes.count(id) == 1) {
+      auto arg = block.getArgument(id);
+      if (!isa<TensorType>(arg.getType())) {
+        continue;
+      }
+      inputTypes.push_back(arg.getType());
+      v = dyn_cast<Value>(arg);
+      inputValues.push_back(v);
+      SmallVector<Value> valuesOnTheWay = {v}; // the constant tensors
+      // For v -> pack1 -> pack2 -> matmul, we need the type of output of pack2
+      while (!v.getUsers().empty()) {
+        // v.getUsers().size() should be 1
+        Operation *user = *(v.getUsers().begin());
+        if (!isInConstantSubgraph(user)) {
+          outputTypes.push_back(v.getType());
+          outputValues.push_back(v);
+          break;
+        }
+        // user should has only 1 output value
+        OpResult result = *(user->result_begin());
+        v = dyn_cast<Value>(result);
+        valuesOnTheWay.push_back(v);
+      }
+
+      // If data size of outputValue is too greater than size of inputValue, do
+      // not fold it. Compare data size changes during traverse to find the last
+      // op that satisfies this condition.
+      int64_t initSize =
+          getTensorSize(dyn_cast<TensorType>(valuesOnTheWay[0].getType()));
+      if (!isa<TensorType>(outputTypes.back()) ||
+          initSize * DATA_SIZE_EXPANDING_THRESHOLD <
+              getTensorSize(dyn_cast<TensorType>(outputTypes.back()))) {
+        size_t lastIdx = 0;
+        for (size_t i = 1; i < valuesOnTheWay.size(); ++i) {
+          int64_t size =
+              getTensorSize(dyn_cast<TensorType>(valuesOnTheWay[i].getType()));
+          if (initSize * DATA_SIZE_EXPANDING_THRESHOLD > size) {
+            lastIdx = i;
+          }
+        }
+        if (lastIdx == 0) { // no suitable value found
+          inputTypes.pop_back();
+          outputTypes.pop_back();
+          inputValues.pop_back();
+          outputValues.pop_back();
+          constArgsIndexes.erase(id);
+        } else {
+          outputTypes.back() = valuesOnTheWay[lastIdx].getType();
+          outputValues.back() = valuesOnTheWay[lastIdx];
+        }
+      }
+    }
+  }
+  if (inputTypes.size() != outputTypes.size()) {
+    return;
+  }
+
+  FunctionType foldFuncType =
+      FunctionType::get(context, inputTypes, outputTypes);
+  auto foldFunc =
+      builder.create<func::FuncOp>(topFunc.getLoc(), funcName, foldFuncType);
+  Block *foldBlock = foldFunc.addEntryBlock();
+  // values of folded constant weights in foldBlock
+  SmallVector<Value> outputValuesInFold;
+  IRMapping mapper;
+  for (Operation *op : constOps) {
+    foldBlock->getOperations().push_back(op->clone(mapper));
+  }
+  // the order of outputValuesInFold is according to the order of corresponding
+  // inputValues
+  for (auto &v : outputValues) {
+    auto foldedV = mapper.lookupOrNull(v);
+    outputValuesInFold.push_back(foldedV);
+    v.replaceUsesWithIf(foldedV, [&](OpOperand &val) {
+      Operation *op = val.getOwner();
+      return op->getBlock() == foldBlock;
+    });
+  }
+
+  auto returnOp =
+      builder.create<func::ReturnOp>(topOp->getLoc(), outputValuesInFold);
+  foldBlock->getOperations().push_back(returnOp);
+  for (size_t i = 0; i < inputValues.size(); ++i) {
+    inputValues[i].replaceUsesWithIf(foldBlock->getArgument(i),
+                                     [&](OpOperand &val) {
+                                       Operation *op = val.getOwner();
+                                       return op->getBlock() == foldBlock;
+                                     });
+  }
+
+  foldFunc.setVisibility(SymbolTable::Visibility::Public);
+  moduleOp.push_back(foldFunc);
+  symbolTable.insert(foldFunc);
+
+  // modify the BlockArguments of block
+  size_t oriNumArgs = block.getNumArguments();
+  size_t argIdx = 0;
+  for (size_t id = 0; id < oriNumArgs; ++id) {
+    if (constArgsIndexes.count(id) == 1) {
+      auto loc = block.getArgument(id).getLoc();
+      BlockArgument foldArg =
+          block.insertArgument(id, outputTypes[argIdx], loc);
+      outputValues[argIdx].replaceUsesWithIf(foldArg, [&](OpOperand &val) {
+        Operation *op = val.getOwner();
+        return op->getBlock() == &block;
+      });
+
+      std::deque<Value> dq;
+      SmallVector<Operation *> opsToErase;
+      dq.push_back(block.getArgument(id + 1));
+      while (!dq.empty()) {
+        Value v = dq.front();
+        dq.pop_front();
+        for (Operation *op : v.getUsers()) {
+          for (auto res : op->getResults()) {
+            dq.push_back(res);
+          }
+          opsToErase.push_back(op);
+        }
+      }
+
+      for (auto it = opsToErase.rbegin(); it != opsToErase.rend(); ++it) {
+        (*it)->erase();
+      }
+      block.eraseArgument(id + 1);
+      ++argIdx;
+    }
+  }
+
+  // modify the compute func signature
+  func::FuncOp computeFunc = cast<func::FuncOp>(topFunc);
+  FunctionType computeFuncType = computeFunc.getFunctionType();
+  computeFunc.setType(FunctionType::get(context, block.getArgumentTypes(),
+                                        computeFuncType.getResults()));
+
+  // Delete dead operations by dialects' canonicalizer
+  RewritePatternSet owningPatterns(context);
+  for (auto *dialect : context->getLoadedDialects())
+    dialect->getCanonicalizationPatterns(owningPatterns);
+
+  ArrayRef<std::string> disabledPatterns, enabledPatterns;
+  std::shared_ptr<const FrozenRewritePatternSet> patterns =
+      std::make_shared<FrozenRewritePatternSet>(
+          std::move(owningPatterns), disabledPatterns, enabledPatterns);
+  GreedyRewriteConfig config;
+  LogicalResult converged =
+      applyPatternsAndFoldGreedily(topOp, *patterns, config);
+  (void)converged;
+
+  // clean up the constant-related attrs on ops
+  for (auto &op : block.getOperations()) {
+    if (op.getAttr("onednn_graph.in_const_subgraph")) {
+      op.removeAttr("onednn_graph.in_const_subgraph");
+    }
+  }
+  for (auto &op : foldBlock->getOperations()) {
+    if (op.getAttr("onednn_graph.in_const_subgraph")) {
+      op.removeAttr("onednn_graph.in_const_subgraph");
+    }
+  }
+}
+
+std::unique_ptr<Pass> createCSTPass() { return std::make_unique<CST>(); }
+
+} // namespace gc
+} // namespace mlir

--- a/src/gc-opt/CMakeLists.txt
+++ b/src/gc-opt/CMakeLists.txt
@@ -2,7 +2,8 @@ set(gc_opt_libs
         ${dialect_libs}
         ${conversion_libs} 
         MLIROptLib 
-        GCPasses)
+        GCPasses
+        GCAnalysis)
 if(GC_MLIR_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GC_MLIR_CXX_FLAGS}")
 endif()

--- a/test/gc/Transforms/test_constant_weights_folding.mlir
+++ b/test/gc/Transforms/test_constant_weights_folding.mlir
@@ -1,0 +1,76 @@
+// RUN: gc-opt --split-input-file -pass-pipeline="builtin.module(csa,cst)" %s | FileCheck %s
+
+// CHECK-LABEL: func.func @entry
+#map = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d2, d4, d6)>
+#map1 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d1, d2, d6 floordiv 2, d5, d3)>
+#map2 = affine_map<(d0, d1, d2, d3, d4, d5, d6) -> (d0, d1, d4, d5)>
+#map3 = affine_map<(d0, d1, d2, d3) -> (d1, d3)>
+#map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+module {
+  // COM: A two-layer mlp. arg0: input feature. arg1: weight of #1 linear. arg2: bias of #1 linear.
+  // COM: arg3: weight of #2 linear. arg4: bias of #2 linear.
+  func.func @entry(%arg0: tensor<64x512xbf16>, %arg1: tensor<512x256xbf16>, %arg2: tensor<256xbf16>, %arg3: tensor<256x1024xbf16>, %arg4: tensor<1024xbf16>) -> tensor<64x1024xbf16> attributes {onednn_graph.const_args = [1 : i32, 2 : i32, 3 : i32, 4 : i32]} {
+    %1 = tensor.empty() : tensor<2x16x32x32xbf16>
+    %packed_arg0 = tensor.pack %arg0 inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %1 : tensor<64x512xbf16> -> tensor<2x16x32x32xbf16>
+    %2 = tensor.empty() : tensor<8x16x32x32xbf16>
+    %packed_arg1 = tensor.pack %arg1 outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %2 : tensor<512x256xbf16> -> tensor<8x16x32x32xbf16>
+    %3 = tensor.empty() : tensor<8x16x16x32x2xbf16>
+    %packed_packed_arg1 = tensor.pack %packed_arg1 inner_dims_pos = [2] inner_tiles = [2] into %3 : tensor<8x16x32x32xbf16> -> tensor<8x16x16x32x2xbf16>
+    %4 = tensor.empty() : tensor<2x8x32x32xbf16>
+    %cst_0 = arith.constant 0.000000e+00 : bf16
+    %5 = linalg.fill ins(%cst_0 : bf16) outs(%4 : tensor<2x8x32x32xbf16>) -> tensor<2x8x32x32xbf16>
+    %6 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%packed_arg0, %packed_packed_arg1 : tensor<2x16x32x32xbf16>, tensor<8x16x16x32x2xbf16>) outs(%5 : tensor<2x8x32x32xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %44 = arith.mulf %in, %in_0 : bf16
+      %55 = arith.addf %out, %44 : bf16
+      linalg.yield %55 : bf16
+    } -> tensor<2x8x32x32xbf16>
+    %15 = tensor.empty() : tensor<8x32xbf16>
+    %packed_arg2 = tensor.pack %arg2 outer_dims_perm = [0] inner_dims_pos = [0] inner_tiles = [32] into %15 : tensor<256xbf16> -> tensor<8x32xbf16>
+    %bc_arg2_init = tensor.empty() : tensor<2x8x32x32xbf16>
+    %bc_arg2 = linalg.broadcast ins(%packed_arg2 : tensor<8x32xbf16>) outs(%bc_arg2_init : tensor<2x8x32x32xbf16>) dimensions = [0, 2]
+    %extf32 = arith.extf %bc_arg2 : tensor<2x8x32x32xbf16> to tensor<2x8x32x32xf32>
+    %cst_2 = arith.constant 2.000000e+00 : f32
+    %extf32_mul2_init = tensor.empty() : tensor<2x8x32x32xf32>
+    %extf32_mul2 = linalg.generic {indexing_maps = [#map4, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%extf32 : tensor<2x8x32x32xf32>) outs(%extf32_mul2_init : tensor<2x8x32x32xf32>) {
+    ^bb0(%in: f32, %out: f32):
+      %8 = arith.mulf %in, %cst_2 : f32
+      linalg.yield %8 : f32
+    } -> tensor<2x8x32x32xf32>
+    %truncbf16 = arith.truncf %extf32_mul2 : tensor<2x8x32x32xf32> to tensor<2x8x32x32xbf16>
+    %7 = linalg.generic {indexing_maps = [#map4, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%truncbf16 : tensor<2x8x32x32xbf16>) outs(%6 : tensor<2x8x32x32xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %45 = arith.addf %in, %out : bf16
+      linalg.yield %45 : bf16
+    } -> tensor<2x8x32x32xbf16>
+    %8 = tensor.empty() : tensor<32x8x32x32xbf16>
+    %packed_arg3 = tensor.pack %arg3 outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %8 : tensor<256x1024xbf16> -> tensor<32x8x32x32xbf16>
+    %9 = tensor.empty() : tensor<32x8x16x32x2xbf16>
+    %packed_packed_arg3 = tensor.pack %packed_arg3 inner_dims_pos = [2] inner_tiles = [2] into %9 : tensor<32x8x32x32xbf16> -> tensor<32x8x16x32x2xbf16>
+    %10 = tensor.empty() : tensor<2x32x32x32xbf16>
+    %11 = linalg.fill ins(%cst_0 : bf16) outs(%10 : tensor<2x32x32x32xbf16>) -> tensor<2x32x32x32xbf16>
+    %12 = linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction", "reduction", "parallel", "parallel", "reduction"]} ins(%7, %packed_packed_arg3 : tensor<2x8x32x32xbf16>, tensor<32x8x16x32x2xbf16>) outs(%11 : tensor<2x32x32x32xbf16>) {
+    ^bb0(%in: bf16, %in_0: bf16, %out: bf16):
+      %46 = arith.mulf %in, %in_0 : bf16
+      %56 = arith.addf %out, %46 : bf16
+      linalg.yield %56 : bf16
+    } -> tensor<2x32x32x32xbf16>
+    %16 = tensor.empty() : tensor<32x32xbf16>
+    %packed_arg4 = tensor.pack %arg4 outer_dims_perm = [0] inner_dims_pos = [0] inner_tiles = [32] into %16 : tensor<1024xbf16> -> tensor<32x32xbf16>
+    %13 = linalg.generic {indexing_maps = [#map3, #map4], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%packed_arg4 : tensor<32x32xbf16>) outs(%12 : tensor<2x32x32x32xbf16>) {
+    ^bb0(%in: bf16, %out: bf16):
+      %47 = arith.addf %in, %out : bf16
+      linalg.yield %47 : bf16
+    } -> tensor<2x32x32x32xbf16>
+    %14 = tensor.empty() : tensor<64x1024xbf16>
+    %unpack = tensor.unpack %13 inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %14 : tensor<2x32x32x32xbf16> -> tensor<64x1024xbf16>
+    return %unpack : tensor<64x1024xbf16>
+  }
+}
+// CHECK: linalg.broadcast
+// CHECK: func.func @fold
+// CHECK: arith.extf
+// CHECK: arith.truncf
+// COM: expected output:
+// COM: func.func @entry(%arg0: tensor<64x512xbf16>, %arg1: tensor<8x16x16x32x2xbf16>, %arg2: tensor<8x32xbf16>, %arg3: tensor<32x8x16x32x2xbf16>, %arg4: tensor<32x32xbf16>) -> tensor<64x1024xbf16>
+// COM: func.func @fold(%arg0: tensor<512x256xbf16>, %arg1: tensor<256xbf16>, %arg2: tensor<256x1024xbf16>, %arg3: tensor<1024xbf16>) -> (tensor<8x16x16x32x2xbf16>, tensor<8x32xbf16>, tensor<32x8x16x32x2xbf16>, tensor<32x32xbf16>)


### PR DESCRIPTION
This PR implements constant_weights_folding pass:
- The input MLIR function will be split into two functions: compute() and fold(). The fold() function contains the constant operations whose input tensors and output tensors are all constant. The compute() function contains other operations that depend on the variable values and folded constant tensors.
- A constant tensor may be fully folded by several sequential operations. If fully folding increases the data size dramatically (i.e., by BroadcastOp), we choose a partial folding.
- Swaps the constant BroadcastOp and the constant operations after it, so that these constant operations can be included into partial folding. Currently there are strong constraints on these ops to ensure correctness.

A manager which allocates/manages/frees the buffers for folded constant weights is needed. It will be implemented later.
