### PR TITLE
action: add license check

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,32 @@
+name: Graph Compiler License Check
+
+on:
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  license-check:
+    name: License Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: true
+
+      - name: Get merge base
+        run: |
+          echo "MERGE_BASE=`git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}`" >> $GITHUB_ENV
+
+      - name: Get changed files
+        run: |
+          echo "CHANGED_FILES=`git diff --name-only $MERGE_BASE ${{ github.event.pull_request.head.sha }} | paste -sd,`" >> $GITHUB_ENV
+
+      - name: Perform license check
+        run: "python scripts/license.py --files $CHANGED_FILES"

--- a/include/gc_version.h
+++ b/include/gc_version.h
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef GC_VERSION_H
 #define GC_VERSION_H
 

--- a/lib/gc/Dialect/Linalgx/LinalgxDialect.cpp
+++ b/lib/gc/Dialect/Linalgx/LinalgxDialect.cpp
@@ -1,4 +1,4 @@
-//===- LinalgxDialect.h - linalgx dialect -----------------------*- C++ -*-===//
+//===-- LinalgxDialect.cpp - linalgx dialect --------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Dialect/Linalgx/LinalgxOps.cpp
+++ b/lib/gc/Dialect/Linalgx/LinalgxOps.cpp
@@ -1,4 +1,4 @@
-//===- LinalgxOps.h - linalgx dialect ops -----------------------*- C++ -*-===//
+//===-- LinalgxOps.cpp - linalgx dialect ops --------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Dialect/Microkernel/MicrokernelDialect.cpp
+++ b/lib/gc/Dialect/Microkernel/MicrokernelDialect.cpp
@@ -1,4 +1,4 @@
-//===- MicrokernelDialect.h - microkernel dialect ---------------*- C++ -*-===//
+//===-- MicrokernelDialect.cpp - microkernel dialect ------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Dialect/Microkernel/MicrokernelOps.cpp
+++ b/lib/gc/Dialect/Microkernel/MicrokernelOps.cpp
@@ -1,4 +1,4 @@
-//===- MicrokernelOps.h - microkernel dialect ops ---------------*- C++ -*-===//
+//===-- MicrokernelOps.cpp - microkernel dialect ops ------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Dialect/OneDNNGraph/OneDNNGraphDialect.cpp
+++ b/lib/gc/Dialect/OneDNNGraph/OneDNNGraphDialect.cpp
@@ -1,4 +1,4 @@
-//===- OneDNNGraphDialect.h - OneDNN input dialect --------------*- C++ -*-===//
+//===-- OneDNNGraphDialect.cpp - OneDNN input dialect -----------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Dialect/OneDNNGraph/OneDNNGraphOps.cpp
+++ b/lib/gc/Dialect/OneDNNGraph/OneDNNGraphOps.cpp
@@ -1,4 +1,4 @@
-//===- OneDNNGraphOps.h - OneDNN input dialect ops --------------*- C++ -*-===//
+//===-- OneDNNGraphOps.cpp - OneDNN input dialect ops -----------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Transforms/OneDNNGraphToLinalg.cpp
+++ b/lib/gc/Transforms/OneDNNGraphToLinalg.cpp
@@ -1,5 +1,4 @@
-//===- OneDNNGraphToLinalg.cpp - OneDNN Graph To Linalg Lowering --*- C++ -*-=//
-//-*-===//
+//===- OneDNNGraphToLinalg.cpp - OneDNNGraph To Linalg Lowering -*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Transforms/TileNamed.cpp
+++ b/lib/gc/Transforms/TileNamed.cpp
@@ -1,4 +1,4 @@
-//===- TileNamed.cpp - Tile Named Linalg Ops --------------------*- C++ -*-===//
+//===-- TileNamed.cpp - Tile Named Linalg Ops -------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/scripts/license.py
+++ b/scripts/license.py
@@ -1,0 +1,164 @@
+# Copyright (C) 2024 Intel Corporation
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime, sys, re, argparse
+from typing import Dict, Set
+
+WIDTH: int = 80
+intel_license: list[str] = [
+    'Copyright \\(C\\) (\\d\\d\\d\\d-)?$YEAR Intel Corporation',
+    '',
+    'Licensed under the Apache License, Version 2.0 (the "License");',
+    'you may not use this file except in compliance with the License.',
+    'You may obtain a copy of the License at',
+    '',
+    'http://www.apache.org/licenses/LICENSE-2.0',
+    '',
+    'Unless required by applicable law or agreed to in writing,',
+    'software distributed under the License is distributed on an "AS IS" BASIS,',
+    'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
+    'See the License for the specific language governing permissions',
+    'and limitations under the License.',
+    'SPDX-License-Identifier: Apache-2.0',
+]
+
+llvm_license: list[str] = [
+    "===-{1,2} $FILE - .* -*\\*- $LANG -\\*-===",
+    '',
+    'This file is licensed under the Apache License v2.0 with LLVM Exceptions.',
+    'See https://llvm.org/LICENSE.txt for license information.',
+    'SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception',
+    '',
+    "===-*===",
+]
+
+def check_license(filepath: str, license: list[str], var: Dict[str, str], re_line: Set[int]):
+    with open(filepath, 'r') as f:
+        idx: int = 0
+        for line in f.readlines():
+            lic: str = license[idx]
+            # replace the variable defined in license
+            for k, v in var.items():
+                lic = lic.replace(k, v)
+            if idx in re_line:
+                if re.search(lic, line) is not None and ("RE_WIDTH" not in var or int(var["RE_WIDTH"]) + 1 == len(line)):
+                    idx += 1
+            elif line.find(lic) != -1:
+                idx += 1
+            if idx == len(license):
+                return True
+        return False
+
+def fix_intel_license(var: Dict[str, str]):
+    lang: str = var['$LANG']
+    cmt: str = "" # comment char
+    if lang == "C\\+\\+":
+        print("/*")
+        cmt = " *"
+    elif lang == "cmake" or lang == "Python":
+        print("#" * WIDTH)
+        cmt = "#"
+    print('%s Copyright (C) %s Intel Corporation' % (cmt, var['$YEAR']))   
+    for i in range(1, len(intel_license)):
+        print('%s %s' % (cmt, intel_license[i]))   
+    if var['$LANG'] == "C\\+\\+":
+        print(" */")
+    elif lang == "cmake" or lang == "Python":
+        print("#" * WIDTH)
+
+def fix_llvm_license(var: Dict[str, str]):
+    lang: str = var['$LANG']
+    cmt: str = "//" # comment char
+    if lang == "Python":
+        cmt = "#"
+    elif lang == "C\\+\\+":
+        lang = "C++"
+
+    part1 = "%s===-- %s - DESC " % (cmt, var['$FILE'])
+    part3 = "-*- %s -*-===%s" % (lang, cmt)
+    part2 = "-" * (WIDTH - len(part1) - len(part3))
+
+    print(part1 + part2 + part3)
+    for i in range(1, len(llvm_license) - 1):
+        print(cmt + " " + llvm_license[i])
+    part1 = cmt + "==="
+    part3 = "===" + cmt
+    part2 = "-" * (WIDTH - len(part1) - len(part3))
+    print(part1 + part2 + part3)
+        
+def use_llvm_license(path: str) -> bool:
+    for folder in ["lib/gc/", 'include/gc/', 'unittests/']:
+        if path.startswith(folder) or path.startswith('./' + folder):
+            return True
+    return False
+                
+year: int = datetime.datetime.now().year
+success: bool = True
+                
+parser = argparse.ArgumentParser(prog = "benchgc license checker")
+parser.add_argument("--files", required=True, type = str, help = "comma seperated file list")
+args = parser.parse_args()
+
+for filepath in args.files.split(','):
+    name: str = filepath.split('/')[-1]
+    var: Dict[str, str] = {}
+    re_line: Set[int] = set()
+
+    lic = list[str]
+
+    if filepath.startswith("test/") or filepath.startswith("./test/"):
+        continue
+
+    if name.endswith(".py"):
+        var['$LANG'] = "Python"
+    else:
+        for suffix in [".c", ".cpp", ".h", ".hpp"]:
+            if name.endswith(suffix):
+                var['$LANG'] = "C\\+\\+"
+
+    is_llvm_license = use_llvm_license(filepath)
+    if is_llvm_license:
+        # llvm license, only check python/cpp now
+        lic = llvm_license
+        re_line.add(0)
+        re_line.add(6)
+        var['$FILE'] = name
+        # the line we read contains a '\n' character, so the expected length should be 81
+        var['RE_WIDTH'] = str(WIDTH)
+        if name.endswith(".td"):
+            var['$LANG'] = "tablegen"
+    else:
+        # intel license
+        lic = intel_license
+        re_line.add(0)
+        var['$YEAR'] = str(year)
+        if name == "CMakeLists.txt":
+            var['$LANG'] = "cmake"
+
+    if "$LANG" not in var:
+        continue
+    if not check_license(filepath, lic, var, re_line):
+        success = False
+        print("Fail         : %s" % filepath)
+        print("Fix license  :")
+        if is_llvm_license:
+            fix_llvm_license(var)
+        else:
+            fix_intel_license(var)
+    else:
+        print("Success      : %s" % filepath)
+            
+sys.exit(0 if success else 1)

--- a/test/dnnl/dnnl_test_utils.hpp
+++ b/test/dnnl/dnnl_test_utils.hpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include <filesystem>
 #include <fstream>
 #include <sstream>

--- a/test/dnnl/test_dnnl_c_interface.cpp
+++ b/test/dnnl/test_dnnl_c_interface.cpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "dnnl_graph_compiler.h"
 #include "dnnl_test_utils.hpp"
 #include "gc_version.h"

--- a/unittests/Example/Example.cpp
+++ b/unittests/Example/Example.cpp
@@ -1,6 +1,6 @@
-//===- Example.cpp - Tests for Example ------------------------------------===//
+//===-- Example.cpp - Tests for Example -------------------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //


### PR DESCRIPTION
Add license check
Files in the changeset with suffix `.c`, `.cpp`, `.h`, `.hpp`, `.py`, `CMakeLists.txt` will be checked.
Please see the result at #86 and [url](https://github.com/intel/graph-compiler/actions/runs/9124527004/job/25088869295?pr=86)