### PR TITLE
Remove trailing space in the recommanded license to pass the clang-format check

### DIFF
--- a/scripts/license.py
+++ b/scripts/license.py
@@ -93,7 +93,7 @@ def fix_llvm_license(var: Dict[str, str]):
 
     print(part1 + part2 + part3)
     for i in range(1, len(llvm_license) - 1):
-        print(cmt + " " + llvm_license[i])
+        print((cmt + " " + llvm_license[i]).rstrip())
     part1 = cmt + "==="
     part3 = "===" + cmt
     part2 = "-" * (WIDTH - len(part1) - len(part3))


### PR DESCRIPTION
Try to fix https://github.com/intel/graph-compiler/actions/runs/9205162763/job/25320259726