### PR TITLE
Remove use of legacy bufferization passes

### DIFF
--- a/lib/gc/Transforms/Pipeline.cpp
+++ b/lib/gc/Transforms/Pipeline.cpp
@@ -58,13 +58,11 @@ void populateVectorPasses(mlir::PassManager &pm) {
 // scf + arith + math + vector + memref + linalg.brgemm
 void populateBufferizationPasses(mlir::PassManager &pm) {
   bufferization::OneShotBufferizationOptions options;
+  options.bufferizeFunctionBoundaries = true;
+  options.setFunctionBoundaryTypeConversion(
+      bufferization::LayoutMapOption::IdentityLayoutMap);
   pm.addPass(bufferization::createOneShotBufferizePass(options));
   pm.addPass(createCSEPass());
-  pm.addPass(mlir::func::createFuncBufferizePass());
-  pm.addNestedPass<func::FuncOp>(
-      bufferization::createBufferizationBufferizePass());
-  pm.addNestedPass<func::FuncOp>(
-      bufferization::createFinalizingBufferizePass());
   bufferization::BufferResultsToOutParamsOpts opt{};
   opt.hoistStaticAllocs = true;
   pm.addPass(bufferization::createBufferResultsToOutParamsPass(opt));


### PR DESCRIPTION
Upstream remove the legacy passes https://github.com/llvm/llvm-project/pull/93535/files
We need to switch to one-shot-bufferization solution now.