### PR TITLE
[WIP] Copy LinalgToXeGPU pass from tpp-mlir

### DIFF
--- a/include/gc/Transforms/Passes.h
+++ b/include/gc/Transforms/Passes.h
@@ -36,6 +36,10 @@ namespace MemRef {
 class MemRefDialect;
 }
 
+namespace xegpu {
+class XeGPUDialect;
+}
+
 class PassManager;
 
 namespace gc {

--- a/include/gc/Transforms/Passes.td
+++ b/include/gc/Transforms/Passes.td
@@ -46,4 +46,29 @@ def GCCPUPipeline: Pass<"gc-cpu-pipeline"> {
       "vector::VectorDialect"];
 }
 
+def LinalgToXeGPU : Pass<"linalg-to-xegpu", "func::FuncOp"> {
+  let summary = "Convert linalg dialect to XeGPU dialect.";
+  let description = [{
+    Lower linalg ops to XeGPU dialect.
+  }];
+  let dependentDialects = ["linalg::LinalgDialect",
+                           "gpu::GPUDialect",
+                           "xegpu::XeGPUDialect",
+                           "scf::SCFDialect",
+                           "memref::MemRefDialect",
+                           "arith::ArithDialect",
+                           "math::MathDialect",
+                           "vector::VectorDialect"];
+  let options = [
+    Option<"kTile", "k-tile", "int64_t",
+           /*default=*/"32",
+           "GEMM tile size for reduction dimension.">,
+    Option<"stages", "stages", "int64_t",
+           /*default=*/"1",
+           "Number of cooperative prefetch stages.">,
+    ListOption<"dpasTile", "dpas-tile", "int64_t",
+               "DPAS register block sizes MxNxK">,
+  ];
+}
+
 #endif // GC_DIALECT_GC_PASSES

--- a/include/gc/Transforms/Utils/MatcherUtils.h
+++ b/include/gc/Transforms/Utils/MatcherUtils.h
@@ -1,4 +1,4 @@
-//===- MatcherUtils.h - -----------------------------------------*- C++ -*-===//
+//===- MatcherUtils.h -------------------------------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_IR_MATCHERUTILS_H
-#define TPP_IR_MATCHERUTILS_H
+#ifndef GC_MATCHERUTILS_H
+#define GC_MATCHERUTILS_H
 
 namespace mlir {
 class Value;
@@ -22,53 +22,13 @@ namespace utils {
 bool isTwoDAddOp(linalg::LinalgOp linalgOp,
                  SmallVectorImpl<Value> *capturedOperands = nullptr);
 
-// Returns true if the linalg operation is a 2d eltwsie floating point
-// subtraction.
-bool isTwoDSubOp(linalg::LinalgOp linalgOp,
-                 SmallVectorImpl<Value> *capturedOperands = nullptr);
-
-// Returns true if the linalg operation is a 2d eltwsie floating point
-// multiplication.
-bool isTwoDMulOp(linalg::LinalgOp linalgOp,
-                 SmallVectorImpl<Value> *capturedOperands = nullptr);
-
-// Returns true if the linalg.generic is a 2d eltwise floating point fill
-// operation with zeros.
-bool isTwoDZeroOp(linalg::LinalgOp linalgOp,
-                  SmallVectorImpl<Value> *capturedOperands = nullptr);
-
 // Returns true if the linalg.generic is a 2d eltwise floating point relu
 // operation.
 bool isTwoDReluOp(linalg::LinalgOp linalgOp,
                   SmallVectorImpl<Value> *capturedOperands = nullptr);
 
-// Returns true if the linalg.generic is a 2d floating point copy operation.
-bool isTwoDIdentityOp(linalg::LinalgOp linalgOp,
-                      SmallVectorImpl<Value> *capturedOperands = nullptr);
-
-// Returns true if the linalg.generic can convert to a 2d eltwise floating point
-// addition followed by a floating point relu.
-bool isTwoDBiasReluOp(linalg::LinalgOp linalgOp,
-                      SmallVectorImpl<Value> *capturedOperands = nullptr);
-
-// Returns true if linalgOp is a 2d `linalg.transposeOp`.
-bool isTwoDTransposeOp(linalg::LinalgOp linalgOp,
-                       SmallVectorImpl<Value> *capturedOperands = nullptr);
-
-// Return true if linalgOp is a 2d `linalgFillOp`. The fill is filling the
-// output with zeros.
-bool isTwoDFillOpWithZeros(linalg::LinalgOp linalgOp,
-                           SmallVectorImpl<Value> *capturedOperands = nullptr);
-
-// Return a pair where the first member is true if and only if the operation
-// represents a brgemm in VNNI layout. The second member tells if the brgemm has
-// the batch dimension; it has meaning only if the first field is valid.
-std::pair<bool, bool>
-isBrgemmVnniOp(linalg::GenericOp linalgOp,
-               SmallVectorImpl<Value> *capturedOperands = nullptr);
-
 } // namespace utils
 } // namespace structured_match
 } // namespace mlir
 
-#endif // TPP_IR_MATCHERUTILS_H
+#endif // GC_MATCHERUTILS_H

--- a/include/gc/Transforms/Utils/MatcherUtils.h
+++ b/include/gc/Transforms/Utils/MatcherUtils.h
@@ -1,0 +1,74 @@
+//===- MatcherUtils.h - -----------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_IR_MATCHERUTILS_H
+#define TPP_IR_MATCHERUTILS_H
+
+namespace mlir {
+class Value;
+namespace linalg {
+class LinalgOp;
+class GenericOp;
+} // namespace linalg
+namespace structured_match {
+namespace utils {
+
+// Returns true if the linalg operation is a 2d eltwsie floating point addition.
+bool isTwoDAddOp(linalg::LinalgOp linalgOp,
+                 SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if the linalg operation is a 2d eltwsie floating point
+// subtraction.
+bool isTwoDSubOp(linalg::LinalgOp linalgOp,
+                 SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if the linalg operation is a 2d eltwsie floating point
+// multiplication.
+bool isTwoDMulOp(linalg::LinalgOp linalgOp,
+                 SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if the linalg.generic is a 2d eltwise floating point fill
+// operation with zeros.
+bool isTwoDZeroOp(linalg::LinalgOp linalgOp,
+                  SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if the linalg.generic is a 2d eltwise floating point relu
+// operation.
+bool isTwoDReluOp(linalg::LinalgOp linalgOp,
+                  SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if the linalg.generic is a 2d floating point copy operation.
+bool isTwoDIdentityOp(linalg::LinalgOp linalgOp,
+                      SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if the linalg.generic can convert to a 2d eltwise floating point
+// addition followed by a floating point relu.
+bool isTwoDBiasReluOp(linalg::LinalgOp linalgOp,
+                      SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Returns true if linalgOp is a 2d `linalg.transposeOp`.
+bool isTwoDTransposeOp(linalg::LinalgOp linalgOp,
+                       SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Return true if linalgOp is a 2d `linalgFillOp`. The fill is filling the
+// output with zeros.
+bool isTwoDFillOpWithZeros(linalg::LinalgOp linalgOp,
+                           SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+// Return a pair where the first member is true if and only if the operation
+// represents a brgemm in VNNI layout. The second member tells if the brgemm has
+// the batch dimension; it has meaning only if the first field is valid.
+std::pair<bool, bool>
+isBrgemmVnniOp(linalg::GenericOp linalgOp,
+               SmallVectorImpl<Value> *capturedOperands = nullptr);
+
+} // namespace utils
+} // namespace structured_match
+} // namespace mlir
+
+#endif // TPP_IR_MATCHERUTILS_H

--- a/include/gc/Transforms/Utils/MatcherUtils.h
+++ b/include/gc/Transforms/Utils/MatcherUtils.h
@@ -1,4 +1,4 @@
-//===- MatcherUtils.h -------------------------------------------*- C++ -*-===//
+//===- MatcherUtils.h - Matcher utils ---------------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/gc/Transforms/Utils/StructuredOpMatcher.h
+++ b/include/gc/Transforms/Utils/StructuredOpMatcher.h
@@ -1,4 +1,4 @@
-//===- StructuredOpMatcher.h -------------------------------------*- C++-*-===//
+//===- StructuredOpMatcher.h - Structured op matcher ------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/gc/Transforms/Utils/StructuredOpMatcher.h
+++ b/include/gc/Transforms/Utils/StructuredOpMatcher.h
@@ -1,0 +1,461 @@
+//===- StructuredOpMatcher.h -------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_IR_STRUCTUREDOPMATCHER_H
+#define TPP_IR_STRUCTUREDOPMATCHER_H
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include <functional>
+#include <utility>
+
+namespace mlir {
+class Operation;
+namespace structured_match {
+
+struct KindAdd {
+  static bool classof(const Operation *op) {
+    return isa<arith::AddFOp>(op) || isa<arith::AddIOp>(op);
+  }
+};
+
+struct KindMul {
+  static bool classof(const Operation *op) {
+    return isa<arith::MulFOp>(op) || isa<arith::MulIOp>(op);
+  }
+};
+
+// Base class for the matcher predicates selection tag.
+struct MatchSelector {
+  MatchSelector() = delete;
+  size_t getLowerBound() const { return lowerBound; };
+  size_t getUpperBound() const { return upperBound; };
+
+protected:
+  explicit MatchSelector(size_t lowerBound, size_t upperBound)
+      : lowerBound(lowerBound), upperBound(upperBound) {
+    assert(upperBound > lowerBound);
+  }
+
+private:
+  const size_t lowerBound;
+  const size_t upperBound;
+};
+
+// Selector which specifies that predicate should apply on all values.
+struct MatchAll : public MatchSelector {
+  MatchAll() : MatchSelector(0, std::numeric_limits<size_t>::max()) {}
+};
+
+// Selector which specifies that predicate should apply only on one value at
+// the position `idx`.
+struct MatchOne : public MatchSelector {
+  MatchOne() = delete;
+  MatchOne(size_t idx) : MatchSelector(idx, idx + 1) {}
+};
+
+// Selector which specifies that predicate should apply only on range of values
+// at positions from `lowerBound` up to - but not including - `upperBound`.
+struct MatchRange : public MatchSelector {
+  MatchRange() = delete;
+  MatchRange(size_t lowerBound, size_t upperBound)
+      : MatchSelector(lowerBound, upperBound) {}
+};
+
+// Callable object to check if the number of loops in `op` satisfies `fun`.
+struct NumOfLoops {
+  NumOfLoops() = delete;
+  explicit NumOfLoops(std::function<bool(size_t)> fun) : fun(std::move(fun)){};
+
+  bool operator()(Operation *op) const {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op)) {
+      auto numberOfLoops = linalgOp.getNumLoops();
+      return fun(numberOfLoops);
+    }
+    return false;
+  }
+  std::function<bool(size_t)> fun;
+};
+
+// Callable object to check if the `operand` of `op` has a map that satisfies
+// `fun`.
+struct HasMap {
+  HasMap() = delete;
+  explicit HasMap(std::function<bool(AffineMap)> fun) : fun(std::move(fun)){};
+  explicit HasMap(std::function<bool(AffineMap)> fun, AffineMap *ptrMap)
+      : fun(std::move(fun)), ptrMap(ptrMap){};
+
+  bool operator()(OpOperand *operand, Operation *op) const {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op)) {
+      auto map = linalgOp.getMatchingIndexingMap(operand);
+      assert(fun && "must be a callable target");
+      if (!fun(map))
+        return false;
+      if (ptrMap)
+        *ptrMap = std::move(map);
+      return true;
+    }
+    return false;
+  }
+  std::function<bool(AffineMap map)> fun;
+  AffineMap *ptrMap = nullptr;
+};
+
+// Callble object to verify if `map` is a broadcastable projected permutation
+// map. We require the dimensions to be in sorted order this avoid filtering
+// projected permutation without broadcasting semantics, for example
+// affine_map<(d0, d1) -> (d1, d0)> is rejected.
+struct BroadcastableProjectedPermutation {
+  BroadcastableProjectedPermutation() = default;
+
+  bool operator()(AffineMap map) const {
+    if (map.getNumSymbols() > 0 || map.getNumResults() > map.getNumInputs())
+      return false;
+
+    SmallVector<bool> seen(map.getNumInputs(), false);
+    SmallVector<int64_t> pos;
+    for (auto expr : map.getResults()) {
+      if (auto dim = dyn_cast<AffineDimExpr>(expr)) {
+        if (seen[dim.getPosition()])
+          return false;
+        seen[dim.getPosition()] = true;
+        pos.push_back(dim.getPosition());
+      } else if (auto constExpr = dyn_cast<AffineConstantExpr>(expr)) {
+        if (constExpr.getValue() != 0)
+          return false;
+      } else {
+        return false;
+      }
+    }
+    return llvm::is_sorted(pos);
+  }
+};
+
+// Callable object to verify if `map` is a projected permutation.
+struct ProjectedPermutation {
+  ProjectedPermutation() = default;
+
+  bool operator()(AffineMap map) const { return map.isProjectedPermutation(); }
+};
+
+// Callable object to verify if `map` is an identity map.
+struct Identity {
+  Identity() = default;
+
+  bool operator()(AffineMap map) const { return map.isIdentity(); }
+};
+
+// Callable object to capture any map.
+struct Any {
+  Any() = default;
+
+  bool operator()(AffineMap map) const { return true; }
+};
+
+// Callable object to verify if `operand` has static shape.
+struct HasStaticShape {
+  HasStaticShape() = default;
+  HasStaticShape(SmallVectorImpl<int64_t> *shape) : shape(shape){};
+
+  bool operator()(OpOperand *operand, Operation *op) const {
+    auto operandType = operand->get().getType();
+    if (auto shapedType = dyn_cast_or_null<ShapedType>(operandType)) {
+      if (!shapedType.hasStaticShape())
+        return false;
+      if (shape) {
+        for (int64_t shapeOnDim : shapedType.getShape())
+          shape->push_back(shapeOnDim);
+      }
+    }
+    return true;
+  }
+  SmallVectorImpl<int64_t> *shape = nullptr;
+};
+
+// Callable object to verify if `operand` has static strides.
+// If `operand` is a tensor type or a scalar, return true.
+struct HasStaticStrides {
+  HasStaticStrides() = default;
+  HasStaticStrides(SmallVector<int64_t> *strides) : strides(strides){};
+
+  bool operator()(OpOperand *operand, Operation *op) const {
+    auto operandType = operand->get().getType();
+    SmallVector<int64_t> strides;
+    if (auto memRefType = dyn_cast_or_null<MemRefType>(operandType)) {
+      int64_t offset;
+      if (failed(getStridesAndOffset(memRefType, strides, offset)))
+        return false;
+      if (llvm::any_of(strides, [](int64_t stride) {
+            return stride == ShapedType::kDynamic;
+          })) {
+        return false;
+      }
+      if (this->strides)
+        this->strides->append(strides.begin(), strides.end());
+    }
+    return true;
+  }
+  SmallVectorImpl<int64_t> *strides = nullptr;
+};
+
+// Callable object to verify `operand` to have a rank in `ranks`.
+struct HasRank {
+  HasRank() = delete;
+  explicit HasRank(std::initializer_list<int64_t> ranks) : ranks(ranks){};
+
+  bool operator()(OpOperand *operand, Operation *op) const {
+    auto operandType = operand->get().getType();
+    if (!isa<ShapedType>(operandType))
+      return llvm::is_contained(ranks, HasRank::SCALAR);
+    int64_t rank = cast<ShapedType>(operandType).getRank();
+    return llvm::any_of(
+        ranks, [=](int64_t expectedRank) { return expectedRank == rank; });
+  }
+
+  // There are multiple way to represent a scalar: f32, tensor<f32>.
+  // SCALAR means f32.
+  static constexpr int64_t SCALAR = -1;
+  std::vector<int64_t> ranks;
+};
+
+// Callable object to verify `operand` to have an element type `T`.
+template <typename T> struct HasElementType {
+  bool operator()(OpOperand *operand, Operation *op) const {
+    auto operandType = getElementTypeOrSelf(operand->get().getType());
+    return isa<T>(operandType);
+  }
+};
+
+// Callable object to check if the input is equal to specified `value`.
+template <typename T> struct EqualsTo {
+  EqualsTo() = delete;
+  explicit EqualsTo(T value) : value(value){};
+
+  const T value;
+
+  bool operator()(T value) const { return value == this->value; }
+};
+template <typename T> EqualsTo(T) -> EqualsTo<T>;
+
+// Callable object to check if the input is less than or equal to specified
+// `value`.
+struct LessThanOrEqualTo {
+  LessThanOrEqualTo() = delete;
+  explicit LessThanOrEqualTo(size_t value) : value(value){};
+  const size_t value;
+
+  bool operator()(size_t value) const { return value <= this->value; }
+};
+
+// Callable object to check if the input is greater than or equal to specified
+// `value`.
+struct GreaterThanOrEqualTo {
+  GreaterThanOrEqualTo() = delete;
+  explicit GreaterThanOrEqualTo(size_t value) : value(value){};
+  const size_t value;
+
+  bool operator()(size_t value) const { return value >= this->value; }
+};
+
+// Callable object to check if `op` has tensor semantics.
+struct HasTensorSemantics {
+  HasTensorSemantics() = default;
+
+  bool operator()(Operation *op) const {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op))
+      return linalgOp.hasPureTensorSemantics();
+    return false;
+  }
+};
+
+// Callable object to check if `op` buffer semantics.
+struct HasBufferSemantics {
+  HasBufferSemantics() = default;
+
+  bool operator()(Operation *op) const {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op))
+      return linalgOp.hasPureBufferSemantics();
+    return false;
+  }
+};
+
+// Callable object to validate number of init operands for `op`.
+struct NumDpsInits {
+  NumDpsInits() = delete;
+  explicit NumDpsInits(std::function<bool(size_t)> fun) : fun(std::move(fun)){};
+
+  bool operator()(Operation *op) const {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op))
+      return fun(linalgOp.getNumDpsInits());
+    return false;
+  }
+
+  std::function<bool(size_t)> fun;
+};
+
+// Callable object to check the number of affine map for `op`.
+struct NumAffineMaps {
+  NumAffineMaps() = delete;
+  explicit NumAffineMaps(std::function<bool(size_t)> fun) : fun(std::move(fun)){};
+
+  bool operator()(Operation *op) const {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op))
+      return fun(linalgOp.getIndexingMapsArray().size());
+    return false;
+  }
+
+  std::function<bool(size_t)> fun;
+};
+
+// Callable object to validate number of input operands for `op`.
+struct NumDpsInputs {
+  NumDpsInputs() = delete;
+  explicit NumDpsInputs(std::function<bool(size_t)> fun) : fun(std::move(fun)){};
+
+  bool operator()(Operation *op) {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op))
+      return fun(linalgOp.getNumDpsInputs());
+    return false;
+  }
+
+  std::function<bool(size_t)> fun;
+};
+
+// Callable object to validate number of regions for `op`.
+struct NumRegions {
+  NumRegions() = delete;
+  explicit NumRegions(std::function<bool(size_t)> fun) : fun(std::move(fun)){};
+
+  bool operator()(Operation *op) const {
+    if (auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op))
+      return fun(linalgOp->getNumRegions());
+    return false;
+  }
+
+  std::function<bool(size_t)> fun;
+};
+
+// Logical OR between two predicates.
+struct _OR {
+  _OR() = delete;
+  _OR(std::function<bool(size_t)> lhs, std::function<bool(size_t)> rhs)
+      : lhs(std::move(lhs)), rhs(std::move(rhs)) {}
+
+  bool operator()(size_t num) { return (lhs(num) || rhs(num)); }
+
+  std::function<bool(size_t)> lhs;
+  std::function<bool(size_t)> rhs;
+};
+
+// Callable object to check if `op` adheres to a given property passed
+// as an std::function object.
+struct VerifyOpProperty {
+  VerifyOpProperty() = delete;
+  explicit VerifyOpProperty(std::function<LogicalResult(Operation *op)> fun)
+      : fun(std::move(fun)){};
+
+  bool operator()(Operation *op) {
+    if (succeeded(fun(op)))
+      return true;
+    return false;
+  }
+
+  std::function<LogicalResult(Operation *op)> fun;
+};
+
+// Work-around for template specialization.
+struct WithSingleOpImpl {
+  WithSingleOpImpl() = default;
+
+  bool withSingleOpImpl(StringRef, Region *, Operation *,
+                        SmallVectorImpl<Value> *);
+};
+
+// Callable object to check the `op` region for a single scalar operation OpTy.
+template <typename OpTy> struct WithSingleOp {
+  WithSingleOp() : WithSingleOp(nullptr){};
+  WithSingleOp(SmallVectorImpl<Value> *captures) : captures(captures){};
+
+  bool operator()(Region *region, Operation *op) {
+    return WithSingleOpImpl().withSingleOpImpl(OpTy::getOperationName(), region,
+                                               op, captures);
+  }
+
+private:
+  SmallVectorImpl<Value> *captures;
+};
+
+// Implemenation to allow definition in cpp file
+using TypeCheckFunc = std::function<bool(Operation *)>;
+bool withOpChainImpl(Region *region, Operation *op, SmallVectorImpl<Value> *,
+                     SmallVectorImpl<TypeCheckFunc> &);
+
+// Callable object to check the region for a chain of operations.
+template <typename... OpTy> struct WithOpChain {
+  WithOpChain() : WithOpChain(nullptr){};
+  WithOpChain(SmallVectorImpl<Value> *captures) : captures(captures) {
+    (typeChecks.push_back([](Operation *op) { return isa<OpTy>(op); }), ...);
+  };
+
+  bool operator()(Region *region, Operation *op) {
+    return withOpChainImpl(region, op, captures, typeChecks);
+  }
+
+private:
+  SmallVectorImpl<Value> *captures;
+  SmallVector<TypeCheckFunc> typeChecks;
+};
+
+class StructuredOpMatcher {
+  using PredicateFn = std::function<bool(linalg::LinalgOp)>;
+
+public:
+  StructuredOpMatcher() = default;
+
+  StructuredOpMatcher(PredicateFn &&firstPredicate) {
+    predicates.push_back(std::move(firstPredicate));
+  }
+
+  template <typename OpTy> static StructuredOpMatcher make() {
+    return StructuredOpMatcher(
+        [](linalg::LinalgOp op) { return isa<OpTy>(op.getOperation()); });
+  }
+
+  // Match given `op` using stored predicates.
+  bool match(Operation *op);
+
+  // Predicates on operation.
+  StructuredOpMatcher &operation(std::function<bool(Operation *)>);
+
+  // Predicate on OpOperands.
+  StructuredOpMatcher &input(MatchSelector range,
+                             std::function<bool(OpOperand *, Operation *)>);
+
+  // Predicates on OpOperands.
+  StructuredOpMatcher &output(MatchSelector range,
+                              std::function<bool(OpOperand *, Operation *)>);
+
+  // Predicates on Iterators.
+  StructuredOpMatcher &dim(MatchSelector range,
+                           SmallVector<mlir::utils::IteratorType> kinds);
+  StructuredOpMatcher &dim(MatchSelector range, mlir::utils::IteratorType kind);
+
+  // Predicates on region.
+  StructuredOpMatcher &region(MatchSelector range,
+                              std::function<bool(Region *, Operation *op)>);
+
+private:
+  llvm::SmallVector<PredicateFn> predicates;
+};
+
+} // namespace structured_match
+} // namespace mlir
+
+#endif // TPP_IR_STRUCTUREDOPMATCHER_H

--- a/include/gc/Transforms/Utils/ValueUtils.h
+++ b/include/gc/Transforms/Utils/ValueUtils.h
@@ -1,4 +1,4 @@
-//===- ValueUtils.h - -------------------------------------------*- C++ -*-===//
+//===-- ValueUtils.h - Zero-checking utilities ------------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/include/gc/Transforms/Utils/ValueUtils.h
+++ b/include/gc/Transforms/Utils/ValueUtils.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TPP_TRANSFORMS_UTILS_VALUEUTILS_H
-#define TPP_TRANSFORMS_UTILS_VALUEUTILS_H
+#ifndef GC_TRANSFORMS_UTILS_VALUEUTILS_H
+#define GC_TRANSFORMS_UTILS_VALUEUTILS_H
 
 namespace mlir {
 class Value;
@@ -33,4 +33,4 @@ std::pair<Value, Value> getPtrAndOffset(OpBuilder &builder, Value val,
 } // namespace utils
 } // namespace mlir
 
-#endif // TPP_TRANSFORMS_UTILS_VALUEUTILS_H
+#endif // GC_TRANSFORMS_UTILS_VALUEUTILS_H

--- a/include/gc/Transforms/Utils/ValueUtils.h
+++ b/include/gc/Transforms/Utils/ValueUtils.h
@@ -1,0 +1,36 @@
+//===- ValueUtils.h - -------------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TPP_TRANSFORMS_UTILS_VALUEUTILS_H
+#define TPP_TRANSFORMS_UTILS_VALUEUTILS_H
+
+namespace mlir {
+class Value;
+class OpBuilder;
+namespace utils {
+
+// Returns true if the value is a constant float or integer.
+bool isValConstZero(Value val);
+
+// Returns true if the op defining `val` represents a zero filled tensor.
+bool isZeroTensor(Value val);
+
+// Returns the strides of `val`. The method returns something usefull
+// only if the `val` type is a strided memref and the strides are statically
+// known.
+FailureOr<SmallVector<int64_t>> getStaticStrides(Value val);
+
+// Return the offset and ptr for `val`. Assert if `val`
+// is not a memref.
+std::pair<Value, Value> getPtrAndOffset(OpBuilder &builder, Value val,
+                                        Location loc);
+
+} // namespace utils
+} // namespace mlir
+
+#endif // TPP_TRANSFORMS_UTILS_VALUEUTILS_H

--- a/lib/gc/CAPI/CMakeLists.txt
+++ b/lib/gc/CAPI/CMakeLists.txt
@@ -5,5 +5,6 @@ add_mlir_public_c_api_library(GcCAPI
   MLIROneDNNGraph
   MLIRCPURuntimeDialect
   GCPasses
+  GCGPUPasses
   MLIRCPURuntimeTransforms
 )

--- a/lib/gc/ExecutionEngine/Driver/CMakeLists.txt
+++ b/lib/gc/ExecutionEngine/Driver/CMakeLists.txt
@@ -37,5 +37,6 @@ add_mlir_library(GCJitWrapper
     ${dialect_libs}
     ${conversion_libs} 
     GCPasses
+    GCGPUPasses
   )
 

--- a/lib/gc/Transforms/CMakeLists.txt
+++ b/lib/gc/Transforms/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(Utils)
+
 gc_set_mlir_link_components(MLIR_LINK_COMPONENTS
   MLIRIR
   MLIRSupport
@@ -26,3 +28,4 @@ add_mlir_library(GCPasses
   )
 
 set_property(GLOBAL APPEND PROPERTY GC_PASS_LIBS GCPasses)
+add_subdirectory(GPU)

--- a/lib/gc/Transforms/GPU/CMakeLists.txt
+++ b/lib/gc/Transforms/GPU/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_mlir_library(GCGPUPasses
+  LinalgToXeGPU.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include
+
+  DEPENDS
+    GraphCompilerPassIncGen
+
+  LINK_LIBS PUBLIC
+    MLIRGPUDialect
+    MLIRXeGPUDialect
+    MLIRGPUTransforms
+    MLIRGPUToSPIRV
+    MLIRSCFToGPU
+    MLIRSCFToSPIRV
+    MLIRMathToSPIRV
+    MLIRControlFlowToSPIRV
+    MLIRMemRefTransforms
+    GCUtilsIR
+)
+
+set_property(GLOBAL APPEND PROPERTY GC_PASS_LIBS GCGPUPasses)

--- a/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
+++ b/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
@@ -1,6 +1,6 @@
-//===- LinalgToXeGPU.cpp -----------------------------------------*- C++-*-===//
+//===- LinalgToXeGPU.cpp - Linalg To XeGPU Lowering -*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
+++ b/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
@@ -1,0 +1,1405 @@
+//===- LinalgToXeGPU.cpp -----------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gc/Transforms/Passes.h"
+
+#include "gc/Transforms/Utils/MatcherUtils.h"
+#include "gc/Transforms/Utils/StructuredOpMatcher.h"
+#include "gc/Transforms/Utils/ValueUtils.h"
+
+
+#include "mlir/Conversion/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/TransformOps/Utils.h"
+#include "mlir/Dialect/GPU/Transforms/Passes.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/XeGPU/IR/XeGPU.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+
+#include <numeric>
+#include <optional>
+
+using namespace mlir;
+using namespace mlir::gc;
+using namespace mlir::xegpu;
+
+namespace mlir {
+namespace gc {
+#define GEN_PASS_DEF_LINALGTOXEGPU
+#include "gc/Transforms/Passes.h.inc"
+} // namespace gc
+} // namespace mlir
+
+namespace {
+
+// Represents VNNI configuration for an operand.
+struct VnniConfig {
+  int vnniFactor;
+  int vnniAxis;
+};
+
+// Helper struct to keep track of tiles' position with respect to whole matrix.
+struct TilesArray {
+  TilesArray() = delete;
+  TilesArray(int numRows, int numCols) {
+    assert(((numRows > 0) && (numCols > 0)) && "Expected 2D array shape");
+    for (int i = 0; i < numRows; i++) {
+      tileMatrix.push_back(SmallVector<Value>{});
+      for (int j = 0; j < numCols; j++)
+        tileMatrix[i].push_back(Value{});
+    }
+  }
+  ~TilesArray() = default;
+
+  Value getTile(int row, int col) { return tileMatrix[row][col]; }
+
+  void setTile(int row, int col, Value val) { tileMatrix[row][col] = val; }
+
+  SmallVector<Value> toFlatVector() {
+    SmallVector<Value> flatVector;
+    for (auto row : tileMatrix)
+      flatVector.append(row);
+    return flatVector;
+  }
+
+  SmallVector<SmallVector<Value>> tileMatrix;
+};
+
+// Return DPAS tile sizes if the gemm-like operation fits DPAS hardware.
+static bool isDPASCompatible(linalg::LinalgOp linalgOp, int kTile,
+                             ArrayRef<int64_t> dpasTile) {
+  if (!(isa<linalg::MatmulOp>(linalgOp) ||
+        isa<linalg::BatchReduceMatmulOp>(linalgOp) ||
+        isa<linalg::GenericOp>(linalgOp))) {
+    return false;
+  }
+
+  // Expect MxNxK DPAS register block sizes.
+  if (dpasTile.size() != 3)
+    return false;
+
+  // Only static shapes are supported.
+  if (linalgOp.hasDynamicShape())
+    return false;
+
+  auto aType = cast<ShapedType>(linalgOp.getDpsInputs()[0].getType());
+  auto bType = cast<ShapedType>(linalgOp.getDpsInputs()[1].getType());
+  auto cType = cast<ShapedType>(linalgOp.getDpsInits()[0].getType());
+
+  auto elemTypeA = aType.getElementType();
+  auto elemTypeB = bType.getElementType();
+  auto elemTypeC = cType.getElementType();
+
+  // TODO: Add more DPAS combinations.
+  bool isSupportedPrecision =
+      (elemTypeA.isF16() && elemTypeB.isF16() && elemTypeC.isF16()) ||
+      (elemTypeA.isF16() && elemTypeB.isF16() && elemTypeC.isF32());
+  if (!isSupportedPrecision)
+    return false;
+
+  auto mDim = cType.getShape()[0];
+  auto nDim = cType.getShape()[1];
+  auto kDim = aType.getShape().back();
+
+  // Validate workload sizes.
+  // The computation dimensions must fit into the tiles.
+  // Reduction dimension tile size has to be compatible
+  // with the warp tile.
+  int dpasTileM = dpasTile[0];
+  int dpasTileN = dpasTile[1];
+  int dpasTileK = dpasTile[2];
+  if ((mDim % dpasTileM != 0) || (nDim % dpasTileN != 0) ||
+      (kDim % dpasTileK != 0) || (kTile % dpasTileK != 0)) {
+    return false;
+  }
+
+  return true;
+}
+
+// Verify if linalg operands fulfill lowering constraints.
+static LogicalResult isValidMemrefOperand(linalg::LinalgOp linalgOp,
+                                          Value operand,
+                                          PatternRewriter &rewriter,
+                                          unsigned maxDims = 2) {
+  auto type = dyn_cast<MemRefType>(operand.getType());
+  if (!type) {
+    return rewriter.notifyMatchFailure(
+        linalgOp, "Expect memref operand for XeGPU lowering");
+  }
+
+  if (type.getShape().size() > maxDims) {
+    return rewriter.notifyMatchFailure(
+        linalgOp, "Too high dimensionality for XeGPU operations");
+  }
+
+  auto strides = utils::getStaticStrides(operand);
+
+  if (failed(strides)) {
+    return rewriter.notifyMatchFailure(
+        linalgOp, "Expect static strides for XeGPU lowering");
+  }
+  if (strides->back() != 1) {
+    return rewriter.notifyMatchFailure(linalgOp,
+                                       "Expect unit stride in the innermost "
+                                       "dimension for XeGPU operations");
+  }
+
+  return success();
+}
+
+// Match and, if possible, lower a generic operation to an XeGPU compatible op.
+// Returns the result of the lowered op or nullopt, otherwise.
+static std::optional<Value> lowerGenericOp(linalg::GenericOp genericOp,
+                                           ArrayRef<Value> operands,
+                                           VectorType resType,
+                                           PatternRewriter &rewriter) {
+  Location loc = genericOp.getLoc();
+
+  // Expect operands to be already loaded vectors.
+  for (auto operand : operands) {
+    if (!isa<VectorType>(operand.getType()))
+      return std::nullopt;
+  }
+
+  if (structured_match::utils::isTwoDReluOp(genericOp, /*operands=*/nullptr)) {
+    assert(operands.size() == 1 &&
+           "Invalid number of operands for generic 2D ReLU");
+
+    auto eltType = resType.getElementType();
+    Value zeroConst;
+
+    if (isa<FloatType>(eltType)) {
+      auto floatType = cast<FloatType>(eltType);
+      zeroConst = rewriter.create<arith::ConstantFloatOp>(
+          loc, APFloat::getZero(floatType.getFloatSemantics()), floatType);
+    } else if (isa<IntegerType>(eltType)) {
+      zeroConst = rewriter.create<arith::ConstantIntOp>(loc, 0, eltType);
+    } else {
+      // Unhandled type. Bail out.
+      return std::nullopt;
+    }
+
+    auto zeroVec =
+        rewriter.create<vector::BroadcastOp>(loc, resType, zeroConst);
+
+    return rewriter
+        .create<arith::MaximumFOp>(loc, resType, operands[0], zeroVec)
+        .getResult();
+  }
+
+  if (structured_match::utils::isTwoDAddOp(genericOp, /*operands=*/nullptr)) {
+    assert(operands.size() == 2 &&
+           "Invalid number of operands for generic 2D add");
+    return rewriter
+        .create<arith::AddFOp>(loc, resType, operands[0], operands[1])
+        .getResult();
+  }
+
+  return std::nullopt;
+}
+
+// Lower an elementwise operation to an XeGPU compatible op.
+// Returns the result of the lowered op or nullopt, otherwise.
+static std::optional<Value> lowerEltwiseOp(linalg::LinalgOp linalgOp,
+                                           ArrayRef<Value> operands,
+                                           PatternRewriter &rewriter) {
+  Location loc = linalgOp.getLoc();
+
+  assert(llvm::all_of(operands,
+                      [&](Value tile) {
+                        return tile.getType() == operands[0].getType();
+                      }) &&
+         "All eltwise operands must have the same type.");
+
+  // Expect operands to be already loaded vectors.
+  for (auto operand : operands) {
+    if (!isa<VectorType>(operand.getType()))
+      return std::nullopt;
+  }
+
+  auto operandType = cast<ShapedType>(operands[0].getType());
+  auto resType =
+      VectorType::get(operandType.getShape(), operandType.getElementType());
+  auto eltType = resType.getElementType();
+
+  return llvm::TypeSwitch<Operation *, std::optional<Value>>(linalgOp)
+      .Case([&](linalg::AbsOp absOp) -> std::optional<Value> {
+        assert(operands.size() == 1 && "Invalid number of operands for abs");
+        if (isa<FloatType>(eltType)) {
+          return rewriter.create<math::AbsFOp>(loc, resType, operands[0])
+              .getResult();
+        }
+        if (isa<IntegerType>(eltType)) {
+          return rewriter.create<math::AbsIOp>(loc, resType, operands[0])
+              .getResult();
+        }
+        // Unhandled type. Bail out.
+        return std::nullopt;
+      })
+      .Case([&](linalg::AddOp addOp) -> std::optional<Value> {
+        assert(operands.size() == 2 && "Invalid number of operands for add");
+        if (isa<FloatType>(eltType)) {
+          return rewriter
+              .create<arith::AddFOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        if (isa<IntegerType>(eltType)) {
+          return rewriter
+              .create<arith::AddIOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        // Unhandled type. Bail out.
+        return std::nullopt;
+      })
+      .Case([&](linalg::CeilOp ceilOp) -> std::optional<Value> {
+        assert(operands.size() == 1 && "Invalid number of operands for ceil");
+        return rewriter.create<math::CeilOp>(loc, resType, operands[0])
+            .getResult();
+      })
+      .Case([&](linalg::DivOp divOp) -> std::optional<Value> {
+        assert(operands.size() == 2 && "Invalid number of operands for div");
+        if (isa<FloatType>(eltType)) {
+          return rewriter
+              .create<arith::DivFOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        if (isa<IntegerType>(eltType)) {
+          return rewriter
+              .create<arith::DivSIOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        // Unhandled type. Bail out.
+        return std::nullopt;
+      })
+      .Case([&](linalg::DivUnsignedOp divUnsignedOp) -> std::optional<Value> {
+        assert(operands.size() == 2 &&
+               "Invalid number of operands for unsigned div");
+        if (isa<IntegerType>(eltType)) {
+          return rewriter
+              .create<arith::DivUIOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        // Unhandled type. Bail out.
+        return std::nullopt;
+      })
+      .Case([&](linalg::ExpOp expOp) -> std::optional<Value> {
+        assert(operands.size() == 1 && "Invalid number of operands for exp");
+        return rewriter.create<math::ExpOp>(loc, resType, operands[0])
+            .getResult();
+      })
+      .Case([&](linalg::FloorOp floorOp) -> std::optional<Value> {
+        assert(operands.size() == 1 && "Invalid number of operands for floor");
+        return rewriter.create<math::FloorOp>(loc, resType, operands[0])
+            .getResult();
+      })
+      .Case([&](linalg::MaxOp maxOp) -> std::optional<Value> {
+        assert(operands.size() == 2 && "Invalid number of operands for max");
+        if (isa<FloatType>(eltType)) {
+          return rewriter
+              .create<arith::MaximumFOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        if (isa<IntegerType>(eltType)) {
+          if (eltType.isUnsignedInteger()) {
+            return rewriter
+                .create<arith::MaxUIOp>(loc, resType, operands[0], operands[1])
+                .getResult();
+          } else {
+            return rewriter
+                .create<arith::MaxSIOp>(loc, resType, operands[0], operands[1])
+                .getResult();
+          }
+        }
+        // Unhandled type. Bail out.
+        return std::nullopt;
+      })
+      .Case([&](linalg::MulOp mulOp) -> std::optional<Value> {
+        assert(operands.size() == 2 && "Invalid number of operands for mul");
+        if (isa<FloatType>(eltType)) {
+          return rewriter
+              .create<arith::MulFOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        if (isa<IntegerType>(eltType)) {
+          return rewriter
+              .create<arith::MulIOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        // Unhandled type. Bail out.
+        return std::nullopt;
+      })
+      .Case([&](linalg::NegfOp negfOp) -> std::optional<Value> {
+        assert(operands.size() == 1 && "Invalid number of operands for negf");
+        return rewriter.create<arith::NegFOp>(loc, resType, operands[0])
+            .getResult();
+      })
+      .Case([&](linalg::SubOp subOp) -> std::optional<Value> {
+        assert(operands.size() == 2 && "Invalid number of operands for sub");
+        if (isa<FloatType>(eltType)) {
+          return rewriter
+              .create<arith::SubFOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        if (isa<IntegerType>(eltType)) {
+          return rewriter
+              .create<arith::SubIOp>(loc, resType, operands[0], operands[1])
+              .getResult();
+        }
+        // Unhandled type. Bail out.
+        return std::nullopt;
+      })
+      .Case([&](linalg::GenericOp genericOp) -> std::optional<Value> {
+        return lowerGenericOp(genericOp, operands, resType, rewriter);
+      })
+      .Default(
+          [&](Operation *op) -> std::optional<Value> { return std::nullopt; });
+}
+
+// Get static GPU block sizes represented by a surrounding operation
+// like a kernel launch or parallel loop.
+// Returns known block sizes if they are all static or failure, otherwise.
+static FailureOr<SmallVector<int64_t>> getStaticBlockSizes(Operation *op) {
+  if (!op)
+    return failure();
+
+  auto getConstVal = [&](Value val) -> std::optional<int64_t> {
+    if (auto constOp = val.getDefiningOp<arith::ConstantIndexOp>()) {
+      return constOp.value();
+    }
+    return std::nullopt;
+  };
+
+  if (auto launchOp = dyn_cast<gpu::LaunchOp>(op)) {
+    auto sizeX = getConstVal(launchOp.getBlockSizeX());
+    auto sizeY = getConstVal(launchOp.getBlockSizeY());
+    auto sizeZ = getConstVal(launchOp.getBlockSizeZ());
+    if (!sizeX || !sizeY || !sizeZ)
+      return failure();
+
+    return SmallVector<int64_t>{*sizeX, *sizeY, *sizeZ};
+  }
+
+  // TODO: Remove when the lowering only occurs within a gpu.launch op.
+  //       Manually computing this is brittle and duplicated parallel
+  //       loops to gpu conversion.
+  if (auto blockLoop = dyn_cast<scf::ParallelOp>(op)) {
+    auto gridLoop = blockLoop->getParentOfType<scf::ParallelOp>();
+
+    // Blocks or number of threads are represented by the first parallel loop
+    // nested within another parallel loop.
+    //
+    // Fail if there is no outer parallel loop or current loop is nested more
+    // than once.
+    if (!gridLoop || (gridLoop->getParentOfType<scf::ParallelOp>())) {
+      return failure();
+    }
+
+    SmallVector<int64_t> blockSizes;
+    for (auto [lb, ub, step] :
+         llvm::zip_equal(blockLoop.getLowerBound(), blockLoop.getUpperBound(),
+                         blockLoop.getStep())) {
+      auto lbVal = getConstVal(lb);
+      auto ubVal = getConstVal(ub);
+      auto stepVal = getConstVal(step);
+      if (!lbVal || !ubVal || !stepVal)
+        return failure();
+
+      int64_t blockSize = (*ubVal - *lbVal) / *stepVal;
+
+      // There must be at least one subgroup created for each dimension.
+      // Otherwise, bail out and let kernel outlining fail later.
+      if (blockSize <= 0)
+        return failure();
+      blockSizes.push_back(blockSize);
+    }
+
+    // Too many dimensions, something went wrong. Bail out.
+    if (blockSizes.size() > 3)
+      return failure();
+
+    return blockSizes;
+  }
+
+  return failure();
+}
+
+// Get linearized GPU thread ID.
+static Value getGpuLinearThreadId(PatternRewriter &rewriter, Location loc) {
+  SmallVector<Value, 3> threadIds;
+  SmallVector<Value, 3> blockDims;
+
+  for (auto dim : {gpu::Dimension::x, gpu::Dimension::y, gpu::Dimension::z}) {
+    threadIds.push_back(rewriter.create<gpu::ThreadIdOp>(loc, dim));
+    blockDims.push_back(rewriter.create<gpu::BlockDimOp>(loc, dim));
+  }
+
+  // The default GPU indexing is modeled after CUDA:
+  // linear index = (z * sizeY + y) * sizeX + x
+  Value threadId =
+      rewriter.create<arith::MulIOp>(loc, threadIds[2], blockDims[1]);
+  threadId = rewriter.create<arith::AddIOp>(loc, threadId, threadIds[1]);
+  threadId = rewriter.create<arith::MulIOp>(loc, threadId, blockDims[0]);
+  threadId = rewriter.create<arith::AddIOp>(loc, threadId, threadIds[0]);
+
+  return threadId;
+}
+
+// Create a GEMM input tile to be loaded by each subgroup in
+// cooperative fashion.
+// Optionally accepts batch IV for batched GEMM input loading.
+// Returns failure if it is unable to split block/workgroup for
+// prefetching.
+static FailureOr<xegpu::CreateNdDescOp>
+createGemmCoopPrefetchTile(PatternRewriter &rewriter, linalg::LinalgOp linalgOp,
+                           unsigned inputPos, int64_t numThreads,
+                           ArrayRef<int> blockTile, ArrayRef<int> threadTile,
+                           int tileStep) {
+  assert(inputPos <= 1 && "Can handle only GEMM inputs: mat A or mat B");
+  Location loc = linalgOp.getLoc();
+
+  Value src = linalgOp.getDpsInputs()[inputPos];
+
+  // Get a top level view into the whole matrix not only the thread slice.
+  if (auto subview = dyn_cast_or_null<memref::SubViewOp>(src.getDefiningOp())) {
+    src = subview.getSource();
+  }
+
+  const int tileRows = inputPos == 0 ? blockTile[0] : tileStep;
+  const int tileCols = inputPos == 0 ? tileStep : blockTile[1];
+
+  const int numElements = tileRows * tileCols;
+  const int elementsPerThread = numElements / numThreads;
+
+  // Limit the maximum prefetching row length to avoid very wide tiles.
+  //
+  // Currently, the max row size is capped by the hardware max load width.
+  //
+  // TODO: Expose as a tunable parameter or add some heuristics.
+  const int maxRowLength = 32;
+
+  // Prioritize first loading contiguous elements (row lenght/number of
+  // columns) only then gather any remaining elements to be loaded from
+  // further rows.
+  // Also, ensure that the prefetch tile stays within the tile bounds.
+  //
+  // Ideally, prefetch tile sizes should be derived from total number of
+  // elements to be loaded, number of threads/workitems, and hardware load
+  // size limits. Large prefetch tiles might need to be split into sub-tiles.
+  const int numCols =
+      std::min(std::min(elementsPerThread, tileCols), maxRowLength);
+  const int numRows = elementsPerThread / numCols;
+
+  // Bail on invalid prefetching tiles config.
+  if (numRows == 0 ||
+      ((numRows * numCols * numThreads) > (tileRows * tileCols)))
+    return failure();
+
+  auto srcType = cast<ShapedType>(src.getType());
+
+  auto prefetchType =
+      xegpu::TensorDescType::get({numRows, numCols}, srcType.getElementType());
+
+  Value threadId = getGpuLinearThreadId(rewriter, loc);
+
+  // TODO: Simplify block offsets.
+  //       Prefetching tile should be derived from the matmul op operands and
+  //       exposed as a subview.
+  //
+  // Add offset if there are multiple blocks in the current tile's non-reduction
+  // dimension.
+  Value blockOffset = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  if (blockTile[inputPos] / threadTile[inputPos] > 1) {
+    Value blockSize =
+        rewriter.create<arith::ConstantIndexOp>(loc, blockTile[inputPos]);
+
+    // For matrix B, pick correct block dimension.
+    // Block min X has to be used if there is no thread tiling in the rows
+    // (dim X) but only in columns (dim Y).
+    gpu::Dimension gpuDim = gpu::Dimension::x;
+    if ((inputPos == 1) && (blockTile[0] / threadTile[0] > 1)) {
+      gpuDim = gpu::Dimension::y;
+    }
+    Value blockId = rewriter.create<gpu::BlockIdOp>(loc, gpuDim);
+
+    blockOffset = rewriter.create<arith::MulIOp>(loc, blockId, blockSize);
+  }
+
+  Value numColTiles =
+      rewriter.create<arith::ConstantIndexOp>(loc, tileStep / numCols);
+  if (inputPos == 1) {
+    numColTiles =
+        rewriter.create<arith::ConstantIndexOp>(loc, blockTile[1] / numCols);
+  }
+  Value tileRowOffset =
+      rewriter.create<arith::DivUIOp>(loc, threadId, numColTiles);
+  Value tileColOffset =
+      rewriter.create<arith::RemUIOp>(loc, threadId, numColTiles);
+
+  Value tileRowSize = rewriter.create<arith::ConstantIndexOp>(loc, numRows);
+  Value tileColSize = rewriter.create<arith::ConstantIndexOp>(loc, numCols);
+  Value eltRowOffset =
+      rewriter.create<arith::MulIOp>(loc, tileRowOffset, tileRowSize);
+  Value eltColOffset =
+      rewriter.create<arith::MulIOp>(loc, tileColOffset, tileColSize);
+
+  if (inputPos == 0) {
+    eltRowOffset =
+        rewriter.create<arith::AddIOp>(loc, eltRowOffset, blockOffset);
+  } else {
+    eltColOffset =
+        rewriter.create<arith::AddIOp>(loc, eltColOffset, blockOffset);
+  }
+
+  SmallVector<mlir::OpFoldResult> prefetchOffsets{eltRowOffset, eltColOffset};
+
+  return rewriter.create<xegpu::CreateNdDescOp>(
+      loc, prefetchType, dyn_cast<TypedValue<MemRefType>>(src),
+      prefetchOffsets);
+}
+
+// Insert prefetches for the given tensor descriptors.
+static void prefetchTiles(PatternRewriter &rewriter, Location loc,
+                          ValueRange prefetchTiles,
+                          xegpu::CachePolicyAttr readCacheHint) {
+  // Prefetch the next set of input tiles.
+  for (auto tile : prefetchTiles) {
+    rewriter.create<xegpu::PrefetchNdOp>(loc, tile,
+                                         /*l1_hint=*/readCacheHint,
+                                         /*l2_hint=*/readCacheHint,
+                                         /*l3_hint=*/readCacheHint);
+  }
+}
+
+// Update all tensor descriptors offsets with the fixed offsets.
+static SmallVector<Value> updateTilesOffsets(PatternRewriter &rewriter,
+                                             Location loc, ValueRange tiles,
+                                             ArrayRef<int64_t> offsets) {
+  SmallVector<Value> updatedTiles;
+  for (auto tile : tiles) {
+    auto updatedTile =
+        rewriter
+            .create<xegpu::UpdateNdOffsetOp>(loc, tile.getType(), tile,
+                                             /*offsets=*/ValueRange{}, offsets)
+            .getResult();
+    updatedTiles.push_back(updatedTile);
+  }
+
+  return updatedTiles;
+}
+
+// Split a source into a series of descriptor tiles.
+//
+// The descriptors collectively load a 2D shape at the specified offsets from
+// the given source.
+// The offsets and the load shape must stay within the source boundaries.
+//
+// The descriptor sub-tiles are ordered in row-major fashion with respect to the
+// whole load tile.
+static SmallVector<Value> createDescriptorTiles(PatternRewriter &rewriter,
+                                                Location loc, Value src,
+                                                ArrayRef<int64_t> loadShape,
+                                                ArrayRef<int64_t> loadOffsets,
+                                                ArrayRef<int64_t> descTile,
+                                                int arrayLength = 1) {
+  assert(arrayLength == 1 && "Array descriptors are not supported");
+
+  auto type = cast<ShapedType>(src.getType());
+  auto descType = xegpu::TensorDescType::get(descTile, type.getElementType());
+
+  // Create the root descriptor.
+  //
+  // It is more efficient to create remainig descriptors by only updating its
+  // offsets compared to creating separate descriptors.
+  // The original tile is split into contiguous sub-tiles so, the first tile
+  // can be used as an anchor.
+  Value rootOffsetRow =
+      rewriter.create<arith::ConstantIndexOp>(loc, loadOffsets[0]);
+  Value rootOffsetCol =
+      rewriter.create<arith::ConstantIndexOp>(loc, loadOffsets[1]);
+
+  mlir::SmallVector<mlir::OpFoldResult> offsets{rootOffsetRow, rootOffsetCol};
+  auto rootTile =
+      rewriter
+          .create<xegpu::CreateNdDescOp>(
+              loc, descType, dyn_cast<TypedValue<MemRefType>>(src), offsets)
+          .getResult();
+
+  SmallVector<Value> tiles;
+  for (int i = 0; i < loadShape[0]; i += descTile[0]) {
+    for (int j = 0; j < loadShape[1]; j += descTile[1] * arrayLength) {
+      auto tile = rewriter
+                      .create<xegpu::UpdateNdOffsetOp>(
+                          loc, descType, rootTile,
+                          /*offsets=*/ValueRange{}, SmallVector<int64_t>{i, j})
+                      .getResult();
+      tiles.push_back(tile);
+    }
+  }
+
+  return tiles;
+}
+
+// Create coarse sub-tiles to be loaded by the current subgroup.
+//
+// The shape to be loaded is split into the largest 2D loads supported
+// by the hardware.
+//
+// The load subgroup tiles are ordered in row-major fashion with respect to the
+// source shape.
+static SmallVector<Value> createCoarseDscTiles(PatternRewriter &rewriter,
+                                               Location loc, Value src,
+                                               ArrayRef<int64_t> sgTile,
+                                               bool isVnni) {
+  assert(sgTile.size() <= 2 &&
+         "Require at most 2D tile size for eltwise lowering");
+
+  // Ensure that load is 2D.
+  // TODO: Add support for 1D loads.
+  SmallVector<int64_t, 2> sgTile2D{sgTile};
+  if (sgTile.size() == 1)
+    sgTile2D.push_back(1);
+
+  auto type = cast<ShapedType>(src.getType());
+  auto elemByteWidth = type.getElementType().getIntOrFloatBitWidth() / 8;
+
+  // TODO: Fetch actual list of supported load configs.
+  int64_t maxHeight = 32;
+  int64_t maxWidth = 64 / elemByteWidth;
+  // Assumes VNNI-factor 2.
+  // TODO: Make the VNNI-factor flexible.
+  if (isVnni)
+    maxWidth /= 2;
+  int64_t maxArrayLength = 4;
+  int64_t sgLoadRows = std::min(sgTile2D[0], maxHeight);
+  int64_t sgLoadCols = std::min(sgTile2D[1], maxWidth);
+  int64_t arrayLength = std::min(maxWidth / sgLoadCols, maxArrayLength);
+  // In case of partial fit, load only single tile.
+  if (maxWidth % sgLoadCols != 0 || arrayLength != 4 || arrayLength != 2)
+    arrayLength = 1;
+
+  // TODO: Add variable array_length support.
+  arrayLength = 1;
+
+  return createDescriptorTiles(rewriter, loc, src, sgTile2D, {0, 0},
+                               {sgLoadRows, sgLoadCols}, arrayLength);
+}
+
+// Return vector type with specified VNNI shape.
+static VectorType getVnniVector(ArrayRef<int64_t> shape, Type elementType,
+                                VnniConfig vnniConf) {
+  assert(shape.size() == 2 && "Expected plain 2D shape");
+  SmallVector<int64_t> vecShape{shape};
+  vecShape[vnniConf.vnniAxis] /= vnniConf.vnniFactor;
+  vecShape.push_back(vnniConf.vnniFactor);
+  return VectorType::get(vecShape, elementType);
+}
+
+// Loads n-D tiles from memory to registers.
+static SmallVector<Value>
+loadNdDescTiles(PatternRewriter &rewriter, Location loc, ValueRange loadTiles,
+                xegpu::CachePolicyAttr hint,
+                std::optional<VnniConfig> vnniConf = std::nullopt,
+                DenseI64ArrayAttr transpose = nullptr) {
+  // Assume all tiles have the same shape.
+  auto tileType = cast<xegpu::TensorDescType>(loadTiles[0].getType());
+  assert(llvm::all_of(loadTiles,
+                      [&](Value tile) { return tile.getType() == tileType; }) &&
+         "All load tiles must have the same type.");
+
+  VectorType vecLoadType =
+      VectorType::get(tileType.getShape(), tileType.getElementType());
+  IntegerAttr vnniAxisAttr = nullptr;
+  if (vnniConf) {
+    vnniAxisAttr = IntegerAttr::get(rewriter.getI64Type(), vnniConf->vnniAxis);
+    vecLoadType = getVnniVector(tileType.getShape(), tileType.getElementType(),
+                                *vnniConf);
+  }
+
+  SmallVector<Value> loadVec;
+  for (auto tile : loadTiles) {
+    auto loadOp = rewriter.create<xegpu::LoadNdOp>(
+        loc, vecLoadType, tile, vnniAxisAttr, transpose,
+        /*l1_hint=*/hint,
+        /*l2_hint=*/hint, /*l3_hint=*/hint);
+    loadVec.push_back(loadOp);
+  }
+  // TODO: Add split over the array_length > 1.
+  //       The split must preserve row-major ordering of the load tiles.
+
+  return loadVec;
+}
+
+// Splits loaded tiles of a larger 2D tile into individual subtiles and places
+// them in their corresponding positions with respect to the original large
+// tile.
+//
+// The loaded tiles must be perfectly divisible by the specified subtiles.
+// Assumes row-major ordering for both the loaded tiles and the original tile.
+//
+// If the loaded tiles use VNNI layout, corresponding VNNI configuration must be
+// provided.
+static TilesArray
+extractVecSubTiles(PatternRewriter &rewriter, Location loc,
+                   ValueRange loadVecTiles, ArrayRef<int64_t> sgTotalTile,
+                   ArrayRef<int64_t> loadTile, ArrayRef<int64_t> subTile,
+                   std::optional<VnniConfig> vnniConf = std::nullopt) {
+  auto vecLoadType = cast<VectorType>(loadVecTiles[0].getType());
+  assert(llvm::all_of(loadVecTiles,
+                      [&](Value tile) {
+                        return cast<VectorType>(tile.getType()) == vecLoadType;
+                      }) &&
+         "All loaded vectors must have the same type.");
+  assert(vecLoadType.getShape().size() == 2 ||
+         vnniConf && "Requires VNNI config for non 2D loaded tiles");
+
+  // Accumulate all dimensions as the vector might have extra VNNI
+  // dimensions.
+  int loadVecSize = std::accumulate(vecLoadType.getShape().begin(),
+                                    vecLoadType.getShape().end(), 1,
+                                    std::multiplies<int64_t>());
+  auto loadVecFlat = VectorType::get(loadVecSize, vecLoadType.getElementType());
+
+  VectorType vecSubTileType =
+      VectorType::get(subTile, vecLoadType.getElementType());
+  if (vnniConf) {
+    vecSubTileType =
+        getVnniVector(subTile, vecLoadType.getElementType(), *vnniConf);
+  }
+
+  const int totalTileRows = sgTotalTile[0] / loadTile[0];
+  const int totalTileCols = sgTotalTile[1] / loadTile[1];
+
+  const int subTilesPerLoadRow = loadTile[0] / subTile[0];
+  const int subTilePerLoadCol = loadTile[1] / subTile[1];
+
+  const int subTileRows = sgTotalTile[0] / subTile[0];
+  const int subTileCols = sgTotalTile[1] / subTile[1];
+  TilesArray subTiles(subTileRows, subTileCols);
+
+  // Iterate over the total tile.
+  for (int m = 0; m < totalTileRows; m++) {
+    for (int k = 0; k < totalTileCols; k++) {
+      // Load tiles are ordered in row-major fashion.
+      int loadIdx = m * totalTileCols + k;
+      auto sgTotalTile = loadVecTiles[loadIdx];
+      auto castFlat =
+          rewriter.create<vector::ShapeCastOp>(loc, loadVecFlat, sgTotalTile);
+
+      // Iterate over load tiles.
+      // Each load tile contains one or more sub-tiles.
+      for (int i = 0; i < subTilesPerLoadRow; i++) {
+        for (int j = 0; j < subTilePerLoadCol; j++) {
+          const int subTileSize = subTile[0] * subTile[1];
+          int dpasIdx = i * subTilePerLoadCol + j;
+          int offset = dpasIdx * subTileSize;
+
+          auto slice = rewriter.create<vector::ExtractStridedSliceOp>(
+              loc, castFlat, /*offsets=*/ArrayRef<int64_t>{offset},
+              /*sizes=*/ArrayRef<int64_t>{subTileSize},
+              /*strides=*/ArrayRef<int64_t>{1});
+          auto castTile =
+              rewriter.create<vector::ShapeCastOp>(loc, vecSubTileType, slice);
+
+          // Insert the sub-tiles in their position relative to the whole
+          // subgroup tile.
+          int rowIdx = m * subTilesPerLoadRow + i;
+          int colIdx = k * subTilePerLoadCol + j;
+          subTiles.setTile(rowIdx, colIdx, castTile);
+        }
+      }
+    }
+  }
+
+  return subTiles;
+}
+
+// Create XeGPU DPAS kernel out of GEMM-like operation.
+static LogicalResult createDPASKernel(linalg::LinalgOp linalgOp,
+                                      ArrayRef<int64_t> dpasTile, int kTile,
+                                      int prefetchStages,
+                                      PatternRewriter &rewriter) {
+  assert((isa<linalg::MatmulOp>(linalgOp) ||
+          isa<linalg::BatchReduceMatmulOp>(linalgOp) ||
+          isa<linalg::GenericOp>(linalgOp)) &&
+         "Requires a GEMM-like op for DPAS lowering");
+
+  Location loc = linalgOp.getLoc();
+  auto ctx = linalgOp.getContext();
+
+  auto matA = linalgOp.getDpsInputs()[0];
+  auto matB = linalgOp.getDpsInputs()[1];
+  auto matC = linalgOp.getDpsInits()[0];
+
+  auto typeA = cast<ShapedType>(matA.getType());
+  auto typeC = cast<ShapedType>(matC.getType());
+
+  int64_t dpasTileM = dpasTile[0];
+  int64_t dpasTileN = dpasTile[1];
+  int64_t dpasTileK = dpasTile[2];
+
+  // Cache hints for loads and stores.
+  auto readCacheHint =
+      xegpu::CachePolicyAttr::get(ctx, xegpu::CachePolicy::CACHED);
+  auto writeCacheHint =
+      xegpu::CachePolicyAttr::get(ctx, xegpu::CachePolicy::WRITE_BACK);
+
+  bool isBrgemm = isa<linalg::BatchReduceMatmulOp>(linalgOp);
+
+  Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+
+  int dimM = typeC.getShape()[0];
+  int dimN = typeC.getShape()[1];
+  int dimK = typeA.getShape().back();
+
+  // Create C sub-tiles.
+  auto dpasTypeC = xegpu::TensorDescType::get({dpasTileM, dpasTileN},
+                                              typeC.getElementType());
+  SmallVector<Value> tilesC = createDescriptorTiles(
+      rewriter, loc, matC, typeC.getShape(), {0, 0}, dpasTypeC.getShape());
+
+  // Load C sub-tiles.
+  // Fetch the inital values of the output accumulator.
+  SmallVector<Value> loadVecC =
+      loadNdDescTiles(rewriter, loc, tilesC, readCacheHint);
+
+  // DPAS only works with F32 accumulators.
+  auto dpasResType =
+      VectorType::get(dpasTypeC.getShape(), FloatType::getF32(ctx));
+
+  // Extend the accumulation values if needed.
+  auto convOutPrecision = !typeC.getElementType().isF32();
+  if (convOutPrecision) {
+    for (size_t i = 0; i < loadVecC.size(); i++) {
+      auto extOp =
+          rewriter.create<arith::ExtFOp>(loc, dpasResType, loadVecC[i]);
+      loadVecC[i] = extOp.getOut();
+    }
+  }
+
+  // Create a loop and step into it.
+  auto startLoop = [&](int lb, int ub, int step,
+                       ValueRange iterArgs) -> scf::ForOp {
+    Value lbCst = rewriter.create<arith::ConstantIndexOp>(loc, lb);
+    Value ubCst = rewriter.create<arith::ConstantIndexOp>(loc, ub);
+    Value stepCst = rewriter.create<arith::ConstantIndexOp>(loc, step);
+    scf::ForOp loopOp =
+        rewriter.create<scf::ForOp>(loc, lbCst, ubCst, stepCst, iterArgs);
+    rewriter.setInsertionPointToStart(loopOp.getBody());
+    return loopOp;
+  };
+  auto getLoopIterValues = [&](scf::ForOp loopOp) -> SmallVector<Value> {
+    SmallVector<Value> loopIterVals;
+    for (auto iterArg : loopOp.getRegionIterArgs())
+      loopIterVals.push_back(iterArg);
+    return loopIterVals;
+  };
+
+  OpBuilder::InsertionGuard guard(rewriter);
+
+  // Construct and move into batch reduction loop.
+  // Propagate output values as iter args.
+  scf::ForOp batchLoop;
+  Value batchIv;
+  if (isBrgemm) {
+    batchLoop = startLoop(0, typeA.getShape()[0], 1, loadVecC);
+    batchIv = batchLoop.getInductionVar();
+    loadVecC = getLoopIterValues(batchLoop);
+    // TODO: Replace input matrices A and B with subviews on the current
+    //       batchIV as loads can only be performed on 2D memrefs.
+  }
+
+  // Create A sub-tiles.
+  SmallVector<Value> tilesA =
+      createCoarseDscTiles(rewriter, loc, matA, {dimM, kTile}, /*isVnni=*/true);
+
+  // Create B sub-tiles.
+  SmallVector<Value> tilesB =
+      createCoarseDscTiles(rewriter, loc, matB, {kTile, dimN}, /*isVnni=*/true);
+
+  // Create input prefetch tiles.
+  int64_t numThreads = 1;
+  auto blockDims =
+      getStaticBlockSizes(linalgOp->getParentOfType<scf::ParallelOp>());
+  if (succeeded(blockDims)) {
+    numThreads = std::accumulate(blockDims->begin(), blockDims->end(), 1,
+                                 std::multiplies<int64_t>());
+  }
+  // Disable prefetching when there is no block/workgroup parallelism.
+  bool isCoopPrefetch = numThreads > 1;
+
+  Value prefetchA;
+  Value prefetchB;
+  xegpu::TensorDescType prefetchTypeA;
+  xegpu::TensorDescType prefetchTypeB;
+  if (isCoopPrefetch) {
+    // Return dimension size on which the whole block/workgroup operates.
+    auto getBlockLevelSize = [&](Value val, int dim) -> int {
+      if (auto subview =
+              dyn_cast_or_null<memref::SubViewOp>(val.getDefiningOp())) {
+        val = subview.getSource();
+      }
+
+      return cast<ShapedType>(val.getType()).getShape()[dim];
+    };
+
+    int blockRows = getBlockLevelSize(matC, 0);
+    int blockCols = getBlockLevelSize(matC, 1);
+
+    auto prefetchDescA = createGemmCoopPrefetchTile(
+        rewriter, linalgOp, /*inputPos=*/0, numThreads, {blockRows, blockCols},
+        {dimM, dimN}, kTile);
+    auto prefetchDescB = createGemmCoopPrefetchTile(
+        rewriter, linalgOp, /*inputPos=*/1, numThreads, {blockRows, blockCols},
+        {dimM, dimN}, kTile);
+
+    if (succeeded(prefetchDescA) && succeeded(prefetchDescB)) {
+      prefetchA = prefetchDescA->getResult();
+      prefetchTypeA = prefetchDescA->getType();
+      prefetchB = prefetchDescB->getResult();
+      prefetchTypeB = prefetchDescB->getType();
+
+      // Start data prefetching by multistage data load.
+      for (int i = 0; i < prefetchStages; i++) {
+        prefetchTiles(rewriter, loc, ValueRange{prefetchA}, readCacheHint);
+        prefetchTiles(rewriter, loc, ValueRange{prefetchB}, readCacheHint);
+        prefetchA = updateTilesOffsets(rewriter, loc, ValueRange{prefetchA},
+                                       {0, kTile})[0];
+        prefetchB = updateTilesOffsets(rewriter, loc, ValueRange{prefetchB},
+                                       {kTile, 0})[0];
+      }
+    } else {
+      // Disable coop prefetching on failure.
+      isCoopPrefetch = false;
+    }
+  }
+
+  // Construct and move into GEMM reduction dimension tiling loop.
+  // Propagate output values as iter args.
+  SmallVector<Value> iterArgs;
+  iterArgs.append(loadVecC);
+  iterArgs.append(tilesA);
+  iterArgs.append(tilesB);
+  if (isCoopPrefetch) {
+    iterArgs.push_back(prefetchA);
+    iterArgs.push_back(prefetchB);
+  }
+  scf::ForOp kDimLoop = startLoop(0, dimK, kTile, iterArgs);
+  auto iterValues = getLoopIterValues(kDimLoop);
+
+  loadVecC = SmallVector<Value>{iterValues.begin(),
+                                iterValues.begin() + loadVecC.size()};
+  tilesA =
+      SmallVector<Value>{iterValues.begin() + loadVecC.size(),
+                         iterValues.begin() + loadVecC.size() + tilesA.size()};
+  tilesB = SmallVector<Value>{iterValues.begin() + loadVecC.size() + tilesA.size(),
+                              iterValues.begin() + loadVecC.size() + tilesA.size() + tilesB.size()};
+  if (isCoopPrefetch) {
+    prefetchA = *(iterValues.end() - 2);
+    prefetchB = *(iterValues.end() - 1);
+  }
+
+  // Periodically synchronize the block/workgroup to minimize impact on cache
+  // due to replacement of sub-tiles before all threads/workitems consumed
+  // inputs for reduction dimension step.
+  //
+  // TODO: Synchronization frequency should be derived from tile and cache size.
+  int syncFreq = 4;
+  int maxSyncStep = 1024;
+  int syncStep = std::min(std::max(dimK / syncFreq, maxSyncStep), maxSyncStep);
+  auto syncStepConst = rewriter.create<arith::ConstantIndexOp>(loc, syncStep);
+  auto loopStepMod = rewriter.create<arith::RemUIOp>(
+      loc, kDimLoop.getInductionVar(), syncStepConst);
+  auto syncBlockCond = rewriter.create<arith::CmpIOp>(
+      loc, arith::CmpIPredicate::eq, loopStepMod, zero);
+  rewriter.create<scf::IfOp>(
+      loc, syncBlockCond,
+      /*thenBuilder=*/
+      [](OpBuilder &b, Location loc) {
+        b.create<gpu::BarrierOp>(loc);
+        b.create<scf::YieldOp>(loc);
+      },
+      /*elseBuilder=*/nullptr);
+
+  // TODO: Add more possible types.
+  int vnniFactor = TypeSwitch<Type, int>(typeA.getElementType())
+                       .Case([](Float16Type type) { return 2; })
+                       .Default([](Type type) { return -1; });
+  if (vnniFactor == -1)
+    return failure();
+
+  VnniConfig vnniConfA{.vnniFactor = vnniFactor, .vnniAxis = 1};
+  VnniConfig vnniConfB{.vnniFactor = vnniFactor, .vnniAxis = 0};
+
+  // Load A sub-tiles.
+  SmallVector<Value> loadVecA =
+      loadNdDescTiles(rewriter, loc, tilesA, readCacheHint, vnniConfA);
+  auto tileTypeA = cast<xegpu::TensorDescType>(tilesA[0].getType());
+
+  // Load B sub-tiles.
+  SmallVector<Value> loadVecB =
+      loadNdDescTiles(rewriter, loc, tilesB, readCacheHint, vnniConfB);
+  auto tileTypeB = cast<xegpu::TensorDescType>(tilesB[0].getType());
+
+  // Update offsets of the input tiles.
+  // Shift along the reduction dimension.
+  tilesA = updateTilesOffsets(rewriter, loc, tilesA, {0, kTile});
+  tilesB = updateTilesOffsets(rewriter, loc, tilesB, {kTile, 0});
+
+  // Prefetch the next set of input tiles.
+  if (isCoopPrefetch) {
+    // Prefetch all block/workgroup tiles cooperatively.
+    prefetchTiles(rewriter, loc, ValueRange{prefetchA}, readCacheHint);
+    prefetchTiles(rewriter, loc, ValueRange{prefetchB}, readCacheHint);
+    prefetchA =
+        updateTilesOffsets(rewriter, loc, ValueRange{prefetchA}, {0, kTile})[0];
+    prefetchB =
+        updateTilesOffsets(rewriter, loc, ValueRange{prefetchB}, {kTile, 0})[0];
+  } else {
+    // Apply naive prefetching for each subgroup separately.
+    prefetchTiles(rewriter, loc, tilesA, readCacheHint);
+    prefetchTiles(rewriter, loc, tilesB, readCacheHint);
+  }
+
+  // Extract DPAS tiles from loaded sub-tiles.
+  TilesArray dpasVecA = extractVecSubTiles(rewriter, loc, loadVecA,
+                                           {dimM, kTile}, tileTypeA.getShape(),
+                                           {dpasTileM, dpasTileK}, vnniConfA);
+  TilesArray dpasVecB = extractVecSubTiles(rewriter, loc, loadVecB,
+                                           {kTile, dimN}, tileTypeB.getShape(),
+                                           {dpasTileK, dpasTileN}, vnniConfB);
+
+  const int numTilesM = dimM / dpasTileM;
+  const int numTilesN = dimN / dpasTileN;
+  const int numTilesK = kTile / dpasTileK;
+
+  // Compute sub-tiles of the C tile.
+  //
+  // Iterate over the reduction dimension sub-tiles as the outermost
+  // loop to minimize read after write conflicts between partial
+  // computations of the same C sub-tile.
+  SmallVector<Value> dpasResults = loadVecC;
+
+  for (int k = 0; k < numTilesK; k++) {
+    for (int m = 0; m < numTilesM; m++) {
+      for (int n = 0; n < numTilesN; n++) {
+        int cIdx = m * numTilesN + n;
+
+        Value result = rewriter
+                           .create<xegpu::DpasOp>(
+                               loc, dpasResType, dpasVecA.getTile(m, k),
+                               dpasVecB.getTile(k, n), dpasResults[cIdx])
+                           .getResult();
+
+        // Update sub-tile partial result.
+        dpasResults[cIdx] = result;
+      }
+    }
+  }
+
+  // Create loop terminator and exit the loop.
+  auto terminateLoop = [&](scf::ForOp loopOp, SmallVector<Value> resultValues) {
+    rewriter.setInsertionPointToEnd(loopOp.getBody());
+    rewriter.create<scf::YieldOp>(loc, resultValues);
+    rewriter.setInsertionPointAfter(loopOp);
+  };
+
+  SmallVector<Value> yieldVals;
+  yieldVals.append(dpasResults);
+  yieldVals.append(tilesA);
+  yieldVals.append(tilesB);
+  if (isCoopPrefetch) {
+    yieldVals.push_back(prefetchA);
+    yieldVals.push_back(prefetchB);
+  }
+
+  // Terminate and exit reduction dim loop.
+  terminateLoop(kDimLoop, yieldVals);
+  yieldVals = kDimLoop.getResults();
+
+  SmallVector<Value> results{yieldVals.begin(),
+                             yieldVals.begin() + dpasResults.size()};
+
+  // Terminate and exit batch reduce loop.
+  if (isBrgemm) {
+    terminateLoop(batchLoop, results);
+    results = batchLoop.getResults();
+  }
+
+  // Truncate the result values if needed.
+  if (convOutPrecision) {
+    auto truncType =
+        VectorType::get(dpasTypeC.getShape(), typeC.getElementType());
+    for (size_t i = 0; i < results.size(); i++) {
+      auto truncOp =
+          rewriter.create<arith::TruncFOp>(loc, truncType, results[i]);
+      results[i] = truncOp.getOut();
+    }
+  }
+
+  // Write back the final C sub-tiles results to the output buffer.
+  SmallVector<xegpu::StoreNdOp> storeOps;
+  for (size_t i = 0; i < tilesC.size(); i++) {
+    auto storeOp =
+        rewriter.create<xegpu::StoreNdOp>(loc, results[i], tilesC[i],
+                                          /*l1_hint=*/writeCacheHint,
+                                          /*l2_hint=*/writeCacheHint,
+                                          /*l3_hint=*/writeCacheHint);
+    storeOps.push_back(storeOp);
+  }
+
+  rewriter.eraseOp(linalgOp);
+
+  return success();
+}
+
+// Create XeGPU kernel out of elementwise operation.
+LogicalResult createEltwiseKernel(linalg::LinalgOp linalgOp,
+                                  PatternRewriter &rewriter) {
+  Location loc = linalgOp.getLoc();
+  auto ctx = linalgOp.getContext();
+
+  auto output = linalgOp.getDpsInits()[0];
+  auto outputShape = cast<ShapedType>(output.getType()).getShape();
+
+  // Create descriptors and load values for all inputs.
+  SmallVector<SmallVector<Value>> loadedInputs;
+  for (auto input : linalgOp.getDpsInputs()) {
+    SmallVector<Value> inputTiles = createCoarseDscTiles(
+        rewriter, loc, input, outputShape, /*isVnni=*/false);
+    SmallVector<Value> loadedVals =
+        loadNdDescTiles(rewriter, loc, inputTiles, /*hint=*/nullptr);
+    loadedInputs.push_back(loadedVals);
+  }
+
+  // Extract SIMD sized sub-tiles from loaded tiles.
+  // TODO: Fetch SIMD sizes from target descriptor.
+  int maxSizeSIMD = 256;
+  auto loadShape = cast<VectorType>(loadedInputs[0][0].getType()).getShape();
+  // For sake of n-D loads and store, the vectorized operations are kept in 2D
+  // shape. The loaded tiles might be larger than what SIMD units can handle.
+  // Thus, split the registers into contiguous smaller slices. The current
+  // hardware load restrictions ensure that the loaded tile width will not
+  // exceed SIMD size.
+  //
+  // Take at least one whole row plus as many extra rows as can fit into
+  // a single SIMD instruction.
+  int64_t subTileCols = loadShape[1];
+  int64_t subTileRows = std::min(loadShape[0], maxSizeSIMD / subTileCols);
+
+  SmallVector<SmallVector<Value>> vecSubTiles;
+  for (auto inputTiles : loadedInputs) {
+    TilesArray subTiles =
+        extractVecSubTiles(rewriter, loc, inputTiles, outputShape, loadShape,
+                           {subTileRows, subTileCols});
+    vecSubTiles.push_back(subTiles.toFlatVector());
+  }
+
+  // Perform vectorized computations for each output tile.
+  SmallVector<Value> results;
+  for (size_t i = 0; i < vecSubTiles[0].size(); i++) {
+    // Operands are sub-tiles at the same location.
+    SmallVector<Value> operands;
+    for (auto inputs : vecSubTiles) {
+      operands.push_back(inputs[i]);
+    }
+
+    // Create SIMD operations on the sub-tiles.
+    auto res = lowerEltwiseOp(linalgOp, operands, rewriter);
+    if (!res)
+      return failure();
+
+    results.push_back(*res);
+  }
+
+  // Output descriptors for later stores.
+  SmallVector<Value> outputTiles = createDescriptorTiles(
+      rewriter, loc, output, outputShape, {0, 0}, {subTileRows, subTileCols});
+
+  // Store results.
+  auto writeCacheHint =
+      xegpu::CachePolicyAttr::get(ctx, xegpu::CachePolicy::WRITE_BACK);
+  for (size_t i = 0; i < outputTiles.size(); i++) {
+    rewriter.create<xegpu::StoreNdOp>(loc, results[i], outputTiles[i],
+                                      /*l1_hint=*/writeCacheHint,
+                                      /*l2_hint=*/writeCacheHint,
+                                      /*l3_hint=*/writeCacheHint);
+  }
+
+  rewriter.eraseOp(linalgOp);
+
+  return success();
+}
+
+// Convert a GEMM-like operation to an XeGPU kernel.
+template <typename LinalgOpTy>
+struct ConvertGemmLikeToXeGPU : public OpRewritePattern<LinalgOpTy> {
+  using OpRewritePattern<LinalgOpTy>::OpRewritePattern;
+  // Constrain conversion to the supported GEMM-like ops.
+  static_assert(
+      llvm::is_one_of<LinalgOpTy, linalg::MatmulOp, linalg::BatchReduceMatmulOp,
+                      linalg::GenericOp>::value);
+
+  ConvertGemmLikeToXeGPU(MLIRContext *ctx, LinalgToXeGPUOptions options)
+      : OpRewritePattern<LinalgOpTy>(ctx), options(options) {}
+
+  LogicalResult matchAndRewrite(LinalgOpTy gemmLikeOp,
+                                PatternRewriter &rewriter) const override {
+    if (!gemmLikeOp.hasPureBufferSemantics()) {
+      return rewriter.notifyMatchFailure(
+          gemmLikeOp, "Linalg GEMM-like to GPU expects memref type");
+    }
+    if (gemmLikeOp.hasDynamicShape()) {
+      return rewriter.notifyMatchFailure(
+          gemmLikeOp, "Expect static shape when mapping to GPU");
+    }
+
+    using namespace structured_match;
+    auto matmulMatcher =
+        StructuredOpMatcher::make<linalg::GenericOp>()
+            .operation(NumDpsInits(EqualsTo(1)))
+            .operation(NumDpsInputs(EqualsTo(2)))
+            .operation(NumRegions(EqualsTo(1)))
+            .operation(NumOfLoops(EqualsTo(3)))
+            .input(MatchAll(), HasStaticShape())
+            .output(MatchAll(), HasStaticShape())
+            .region(MatchOne(0), WithOpChain<arith::MulFOp, arith::AddFOp>());
+    if (isa<linalg::GenericOp>(gemmLikeOp) &&
+        !matmulMatcher.match(gemmLikeOp)) {
+      return rewriter.notifyMatchFailure(
+          gemmLikeOp, "Generic does not represent a GEMM-like operation");
+    }
+
+    for (auto input : gemmLikeOp.getDpsInputs()) {
+      // 3D inputs are also acceptable in case of brgemm.
+      auto isInputValid =
+          isValidMemrefOperand(gemmLikeOp, input, rewriter, /*maxDims=*/3);
+      if (failed(isInputValid))
+        return isInputValid;
+    }
+    auto isOutputValid =
+        isValidMemrefOperand(gemmLikeOp, gemmLikeOp.getDpsInits()[0], rewriter);
+    if (failed(isOutputValid))
+      return isOutputValid;
+
+    // Ensure that reduction dimension tiling also works for smaller
+    // workloads.
+    auto aType = cast<ShapedType>(gemmLikeOp.getDpsInputs()[0].getType());
+    auto kDim = aType.getShape().back();
+    auto kTile = kDim < options.kTile ? kDim : options.kTile;
+
+    // DPAS hardware sizes in MxNxK format.
+    // TODO: In case more hardware configurations are available,
+    //       add some automatic selection for optimal sizes.
+    if (options.dpasTile.empty()) {
+      return rewriter.notifyMatchFailure(gemmLikeOp, "Expect DPAS block sizes");
+    }
+
+    if (!isDPASCompatible(gemmLikeOp, kTile, options.dpasTile)) {
+      return rewriter.notifyMatchFailure(
+          gemmLikeOp, "GEMM-like compute does not fit in DPAS tiles");
+    }
+
+    return createDPASKernel(gemmLikeOp, options.dpasTile, kTile, options.stages,
+                            rewriter);
+  }
+
+private:
+  LinalgToXeGPUOptions options;
+};
+
+// Convert a named elementwise operation to an XeGPU kernel.
+template <typename LinalgOpTy>
+struct ConvertNamedEltwiseToXeGPU : public OpRewritePattern<LinalgOpTy> {
+  using OpRewritePattern<LinalgOpTy>::OpRewritePattern;
+
+  ConvertNamedEltwiseToXeGPU(MLIRContext *ctx, LinalgToXeGPUOptions options)
+      : OpRewritePattern<LinalgOpTy>(ctx), options(options) {}
+
+  LogicalResult matchAndRewrite(LinalgOpTy eltwiseOp,
+                                PatternRewriter &rewriter) const override {
+    if (!eltwiseOp.hasPureBufferSemantics()) {
+      return rewriter.notifyMatchFailure(
+          eltwiseOp, "Linalg eltwise to GPU expects memref type");
+    }
+    if (eltwiseOp.hasDynamicShape()) {
+      return rewriter.notifyMatchFailure(
+          eltwiseOp, "Expect static shape when mapping to GPU");
+    }
+
+    for (auto input : eltwiseOp.getDpsInputs()) {
+      auto isInputValid = isValidMemrefOperand(eltwiseOp, input, rewriter);
+      if (failed(isInputValid))
+        return isInputValid;
+    }
+    auto isOutputValid =
+        isValidMemrefOperand(eltwiseOp, eltwiseOp.getDpsInits()[0], rewriter);
+    if (failed(isOutputValid))
+      return isOutputValid;
+
+    return createEltwiseKernel(eltwiseOp, rewriter);
+  }
+
+private:
+  LinalgToXeGPUOptions options;
+};
+
+// TODO: Finalize BRGEMM support and register the pattern.
+void populateLinalgGemmToXeGPUPatterns(RewritePatternSet &patterns,
+                                       LinalgToXeGPUOptions options) {
+  patterns.add<ConvertGemmLikeToXeGPU<linalg::MatmulOp>,
+               ConvertGemmLikeToXeGPU<linalg::GenericOp>>(patterns.getContext(),
+                                                          options);
+}
+
+void populateLinalgEltwiseToXeGPUPatterns(RewritePatternSet &patterns,
+                                          LinalgToXeGPUOptions options) {
+  patterns.add<ConvertNamedEltwiseToXeGPU<linalg::AbsOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::AddOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::CeilOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::DivOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::DivUnsignedOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::ExpOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::FloorOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::MaxOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::MulOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::NegfOp>,
+               ConvertNamedEltwiseToXeGPU<linalg::SubOp>>(patterns.getContext(),
+                                                          options);
+}
+
+struct LinalgToXeGPU : public gc::impl::LinalgToXeGPUBase<LinalgToXeGPU> {
+  using LinalgToXeGPUBase::LinalgToXeGPUBase;
+
+  void runOnOperation() override {
+    LinalgToXeGPUOptions options{kTile, stages, dpasTile};
+
+    // Run GEMM pattern first to allow fusion with its consumers.
+    RewritePatternSet gemmPatterns(&getContext());
+    populateLinalgGemmToXeGPUPatterns(gemmPatterns, options);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(gemmPatterns));
+
+    // Convert other remaining ops.
+    RewritePatternSet patterns(&getContext());
+    populateLinalgEltwiseToXeGPUPatterns(patterns, options);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace

--- a/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
+++ b/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
@@ -12,7 +12,6 @@
 #include "gc/Transforms/Utils/StructuredOpMatcher.h"
 #include "gc/Transforms/Utils/ValueUtils.h"
 
-
 #include "mlir/Conversion/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -1008,8 +1007,9 @@ static LogicalResult createDPASKernel(linalg::LinalgOp linalgOp,
   tilesA =
       SmallVector<Value>{iterValues.begin() + loadVecC.size(),
                          iterValues.begin() + loadVecC.size() + tilesA.size()};
-  tilesB = SmallVector<Value>{iterValues.begin() + loadVecC.size() + tilesA.size(),
-                              iterValues.begin() + loadVecC.size() + tilesA.size() + tilesB.size()};
+  tilesB = SmallVector<Value>{
+      iterValues.begin() + loadVecC.size() + tilesA.size(),
+      iterValues.begin() + loadVecC.size() + tilesA.size() + tilesB.size()};
   if (isCoopPrefetch) {
     prefetchA = *(iterValues.end() - 2);
     prefetchB = *(iterValues.end() - 1);

--- a/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
+++ b/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
@@ -774,7 +774,7 @@ extractVecSubTiles(PatternRewriter &rewriter, Location loc,
                       }) &&
          "All loaded vectors must have the same type.");
   assert(vecLoadType.getShape().size() == 2 ||
-         vnniConf && "Requires VNNI config for non 2D loaded tiles");
+         (vnniConf && "Requires VNNI config for non 2D loaded tiles"));
 
   // Accumulate all dimensions as the vector might have extra VNNI
   // dimensions.

--- a/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
+++ b/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
@@ -1,4 +1,4 @@
-//===- LinalgToXeGPU.cpp - Linalg To XeGPU Lowering -*- C++ -*-===//
+//===- LinalgToXeGPU.cpp - Linalg To XeGPU Lowering -------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Transforms/Utils/CMakeLists.txt
+++ b/lib/gc/Transforms/Utils/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_library(GCUtilsIR
+  MatcherUtils.cpp
+  StructuredOpMatcher.cpp
+  ValueUtils.cpp
+
+  ADDITIONAL_HEADER_DIRS
+    ${PROJECT_SOURCE_DIR}/include
+
+  DEPENDS
+    MLIRLinalgDialect
+)

--- a/lib/gc/Transforms/Utils/MatcherUtils.cpp
+++ b/lib/gc/Transforms/Utils/MatcherUtils.cpp
@@ -1,0 +1,475 @@
+//===- MatcherUtils.cpp ------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gc/Transforms/Utils/StructuredOpMatcher.h"
+#include "gc/Transforms/Utils/ValueUtils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+
+namespace mlir {
+namespace structured_match {
+namespace utils {
+
+// Return position of 'pure' iterators in `indexingMap` for the specific
+// linalg operation given the iterator type `iter`. 'pure' iterator are
+// only AffineDimExpr.
+// static llvm::SmallVector<int64_t>
+// getIteratorPos(linalg::LinalgOp linalgOp, AffineMap indexingMap,
+//                mlir::utils::IteratorType iter) {
+//   llvm::SmallVector<int64_t> res;
+//   for (AffineExpr e : indexingMap.getResults()) {
+//     if (auto d = dyn_cast<AffineDimExpr>(e)) {
+//       if (linalgOp.getIteratorTypesArray()[d.getPosition()] == iter &&
+//           llvm::count_if(indexingMap.getResults(), [d](AffineExpr e) {
+//             return e.isFunctionOfDim(d.getPosition());
+//           }) == 1)
+//         res.push_back(d.getPosition());
+//     }
+//   }
+//   return res;
+// }
+
+// // Return true if the linalg.generic can be mapped to a brgemm in VNNI
+// // format.
+// std::pair<bool, bool> isBrgemmVnniOp(linalg::GenericOp linalgOp,
+//                                      SmallVectorImpl<Value> *operands) {
+//   bool hasBatch = false;
+//   auto blockingFactor =
+//       vnni::utils::getVnniBlockingFactor(linalgOp->getOperands()[0].getType());
+//   if (!blockingFactor)
+//     return std::make_pair(false, hasBatch);
+
+//   AffineMap mapOperandA, mapOperandB, mapOperandC;
+//   using namespace structured_match;
+//   // clang-format off
+//   auto matmulMatcher =
+//       StructuredOpMatcher::make<linalg::GenericOp>()
+//           .operation(NumDpsInits(EqualsTo(1)))
+//           .operation(NumDpsInputs(EqualsTo(2)))
+//           .operation(NumRegions(EqualsTo(1)))
+//           .operation(NumOfLoops(_OR(EqualsTo(5), EqualsTo(4))))
+//           .input(MatchAll(), HasStaticShape())
+//           .output(MatchAll(), HasStaticShape())
+//           .input(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &mapOperandA))
+//           .input(MatchOne(1), HasMap(Any(), &mapOperandB))
+//           .output(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &mapOperandC))
+//           .region(MatchOne(0),
+//                   WithOpChain<arith::MulFOp, arith::AddFOp>(operands));
+//   // clang-format on
+//   if (!matmulMatcher.match(linalgOp))
+//     return std::make_pair(false, hasBatch);
+
+//   // Operand C: Two parallel iterators (i and j).
+//   llvm::SmallVector<int64_t> operandCPosIterPar = getIteratorPos(
+//       linalgOp, mapOperandC, mlir::utils::IteratorType::parallel);
+//   if (operandCPosIterPar.size() != 2)
+//     return std::make_pair(false, hasBatch);
+//   int64_t iParIter = operandCPosIterPar[0];
+//   int64_t jParIter = operandCPosIterPar[1];
+
+//   // Operand A: One parallel iterator (i) and two reduction ones (batch and k).
+//   // The batch dimension is optional.
+//   llvm::SmallVector<int64_t> operandAPosIterPar = getIteratorPos(
+//       linalgOp, mapOperandA, mlir::utils::IteratorType::parallel);
+//   if (operandAPosIterPar.size() != 1 || operandAPosIterPar[0] != iParIter)
+//     return std::make_pair(false, hasBatch);
+
+//   llvm::SmallVector<int64_t> operandAPosIterRed = getIteratorPos(
+//       linalgOp, mapOperandA, mlir::utils::IteratorType::reduction);
+//   if (operandAPosIterRed.size() != 2 && operandAPosIterRed.size() != 1)
+//     return std::make_pair(false, hasBatch);
+
+//   int64_t batchRedIter = std::numeric_limits<int64_t>::max();
+//   int64_t kRedIter = std::numeric_limits<int64_t>::max();
+//   if (operandAPosIterRed.size() == 2) {
+//     batchRedIter = operandAPosIterRed[0];
+//     kRedIter = operandAPosIterRed[1];
+//     hasBatch = true;
+//   } else {
+//     kRedIter = operandAPosIterRed[0];
+//   }
+
+//   // Operand B: One parallel iterator (j) and three reduction ones (batch,
+//   // k/VNNI and VNNI).
+//   // The batch dimension is optional.
+//   llvm::SmallVector<int64_t> operandBPosIterPar = getIteratorPos(
+//       linalgOp, mapOperandB, mlir::utils::IteratorType::parallel);
+//   if (operandBPosIterPar.size() != 1 || operandBPosIterPar[0] != jParIter)
+//     return std::make_pair(false, hasBatch);
+
+//   llvm::SmallVector<int64_t> operandBPosIterRed = getIteratorPos(
+//       linalgOp, mapOperandB, mlir::utils::IteratorType::reduction);
+//   if (operandBPosIterRed.empty())
+//     return std::make_pair(false, hasBatch);
+//   if (batchRedIter != std::numeric_limits<int64_t>::max() &&
+//       operandBPosIterRed[0] != batchRedIter) {
+//     return std::make_pair(false, hasBatch);
+//   }
+
+//   auto vnniDim =
+//       vnni::utils::isInVnniLayout(linalgOp, mapOperandB, *blockingFactor);
+//   bool isBrgemmOp = succeeded(vnniDim) && vnniDim->getPosition() == kRedIter;
+//   return std::make_pair(isBrgemmOp, hasBatch);
+// }
+
+// Return true if all the operand have the same type, i.e., no implicit
+// conversion in the linalgOp.
+static LogicalResult hasEqualOperandTypes(Operation *operation) {
+  if (!isa<linalg::LinalgOp>(operation))
+    return failure();
+  auto linalgOp = cast<linalg::LinalgOp>(operation);
+  OpOperand &outputOperand = linalgOp.getDpsInitsMutable()[0];
+  auto elemType = getElementTypeOrSelf(outputOperand.get().getType());
+
+  if (!llvm::all_of(linalgOp.getDpsInitsMutable(), [&](OpOperand &operand) {
+        auto currentOperandType = getElementTypeOrSelf(operand.get().getType());
+        return currentOperandType == elemType;
+      })) {
+    return failure();
+  }
+
+  if (!llvm::all_of(linalgOp.getDpsInputOperands(), [&](OpOperand *operand) {
+        auto currentOperandType =
+            getElementTypeOrSelf(operand->get().getType());
+        return currentOperandType == elemType;
+      })) {
+    return failure();
+  }
+  return success();
+}
+
+static bool isTppOp(linalg::LinalgOp linalgOp) {
+  // clang-format off
+  auto tppMatcher =
+    StructuredOpMatcher::make<linalg::LinalgOp>()
+      .output(MatchAll(), HasStaticShape())
+      .input(MatchAll(), HasStaticShape())
+      .operation(NumRegions(EqualsTo(1)))
+      .output(MatchAll(), HasStaticStrides())
+      .output(MatchAll(), HasElementType<FloatType>())
+      .input(MatchAll(), HasStaticStrides())
+      .operation(VerifyOpProperty(hasEqualOperandTypes));
+  // clang-format on
+  return tppMatcher.match(linalgOp);
+}
+
+static bool isTppBinaryOp(linalg::LinalgOp linalgOp) {
+  // clang-format off
+  auto binaryMatcher =
+      StructuredOpMatcher::make<linalg::LinalgOp>()
+          .operation(NumDpsInits(EqualsTo(1)))
+          .operation(NumDpsInputs(_OR(EqualsTo(1), EqualsTo(2))))
+          .output(MatchAll(), HasRank({2}))
+          // TODO: (lorenzo) When we introduce broadcast op we
+          // will restrict the input to 2d tiles.
+          .input(MatchAll(), HasRank({HasRank::SCALAR, 1, 2}))
+          .dim(MatchAll(), mlir::utils::IteratorType::parallel)
+          .operation(NumOfLoops(EqualsTo(2)))
+          .output(MatchAll(), HasMap(Identity()))
+          .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()));
+  // clang-format on
+  return isTppOp(linalgOp) && binaryMatcher.match(linalgOp);
+}
+
+static bool isTppUnaryOp(linalg::LinalgOp linalgOp) {
+  // clang-format off
+  auto unaryMatcher =
+      StructuredOpMatcher::make<linalg::LinalgOp>()
+          .operation(NumDpsInits(EqualsTo(1)))
+          .operation(NumDpsInputs(_OR(EqualsTo(0), EqualsTo(1))))
+          // TODO: (lorenzo) When we introduce reduce operations
+          // we will relax this constraint, and allow SCALAR, 1d
+          // and 2d.
+          .output(MatchAll(), HasRank({2}))
+          .input(MatchAll(), HasRank({HasRank::SCALAR, 1, 2}))
+          .dim(MatchAll(), mlir::utils::IteratorType::parallel)
+          .operation(NumOfLoops(EqualsTo(2)));
+  // clang-format on
+  return isTppOp(linalgOp) && unaryMatcher.match(linalgOp);
+}
+
+template <typename OpTy>
+static bool isTwoDEltWiseOpOfTypeTy(linalg::LinalgOp linalgOp,
+                                    SmallVectorImpl<Value> *operands) {
+  // clang-format off
+  auto matcher =
+    StructuredOpMatcher::make<linalg::LinalgOp>().region(
+      MatchOne(0), WithSingleOp<OpTy>(operands));
+  // clang-format on
+  return isTppBinaryOp(linalgOp) && matcher.match(linalgOp);
+}
+
+bool isTwoDAddOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
+  return isTwoDEltWiseOpOfTypeTy<arith::AddFOp>(linalgOp, operands);
+}
+
+bool isTwoDSubOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
+  return isTwoDEltWiseOpOfTypeTy<arith::SubFOp>(linalgOp, operands);
+}
+
+bool isTwoDMulOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
+  return isTwoDEltWiseOpOfTypeTy<arith::MulFOp>(linalgOp, operands);
+}
+
+static bool hasReluBody(Operation *op, SmallVectorImpl<Value> *captured) {
+  if (!isa<linalg::LinalgOp>(op))
+    return false;
+  auto linalgOp = cast<linalg::LinalgOp>(op);
+  Region &region = linalgOp->getRegion(0);
+  if (!region.hasOneBlock())
+    return false;
+  if (linalgOp.getNumDpsInits() != 1)
+    return false;
+  Operation *yieldOp = linalgOp.getBlock()->getTerminator();
+  if (yieldOp->getNumOperands() != 1)
+    return false;
+  Operation *innerOp = &(*linalgOp.getBlock()->getOperations().begin());
+
+  // If lhs is a zero get rhs as input for the relu if it is a block argument,
+  // return false otherwise.
+  auto getOperand = [&](Value lhs, Value rhs) -> bool {
+    if (mlir::utils::isZeroTensor(lhs)) {
+      auto blockArg = dyn_cast<BlockArgument>(rhs);
+      if (!blockArg || blockArg.getParentBlock() != linalgOp.getBlock())
+        return false;
+      OpOperand *operand =
+          linalgOp.getMatchingOpOperand(cast<BlockArgument>(rhs));
+      if (captured) {
+        captured->push_back(operand->get());
+        captured->push_back(linalgOp.getDpsInitOperand(0)->get());
+      }
+      return true;
+    }
+    return false;
+  };
+
+  // Multiple patterns map to Relu.
+  if (auto maxfOp = dyn_cast<arith::MaximumFOp>(innerOp)) {
+    // Pattern 1 - arith.maximumf(tensor, const 0)
+    if (yieldOp->getOperand(0).getDefiningOp() != innerOp)
+      return false;
+    Value maxfLhs = maxfOp.getLhs();
+    Value maxfRhs = maxfOp.getRhs();
+
+    return (getOperand(maxfLhs, maxfRhs) || getOperand(maxfRhs, maxfLhs));
+  }
+  if (auto cmpfOp = dyn_cast<arith::CmpFOp>(innerOp)) {
+    // Pattern 2 - arith.cmpf, arith.select
+    //
+    // x = arith.cmpf ugt, value, 0
+    // y = arith.select x, value, 0
+    //
+    // NOTE: ugt - unsigned greater than, one of the predicates
+    if (linalgOp.getBlock()->getOperations().size() != 3)
+      return false;
+
+    auto opIterator = linalgOp.getBlock()->getOperations().begin();
+    Operation *cmpOp = &*opIterator;
+    opIterator++;
+
+    if (!isa<arith::SelectOp>(&*opIterator))
+      return false;
+
+    Operation *selectOp = &*opIterator;
+    opIterator++;
+    if (yieldOp != &*opIterator)
+      return false;
+
+    if (yieldOp->getOperand(0).getDefiningOp() != selectOp)
+      return false;
+
+    if (selectOp->getOperand(0).getDefiningOp() != cmpOp)
+      return false;
+
+    auto cmpPredicate = cmpfOp.getPredicate();
+    Value cmpLhs = cmpfOp.getLhs();
+    Value cmpRhs = cmpfOp.getRhs();
+
+    auto selOp = cast<arith::SelectOp>(selectOp);
+    auto trueVal = selOp.getTrueValue();
+    auto falseVal = selOp.getFalseValue();
+
+    if (cmpPredicate == arith::CmpFPredicate::UGT ||
+        cmpPredicate == arith::CmpFPredicate::UGE) {
+      if (cmpLhs == trueVal &&
+          mlir::utils::isZeroTensor(cmpRhs) &&
+          mlir::utils::isZeroTensor(falseVal)) {
+        // case: %in > 0 ? %in : 0
+        return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
+      }
+      if (mlir::utils::isZeroTensor(cmpLhs) &&
+          mlir::utils::isZeroTensor(trueVal) && cmpRhs == falseVal) {
+        // case: 0 > %in ? 0 : %in
+        return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
+      }
+    } else if (cmpPredicate == arith::CmpFPredicate::ULT ||
+               cmpPredicate == arith::CmpFPredicate::ULE) {
+      if (cmpLhs == falseVal &&
+          mlir::utils::isZeroTensor(cmpRhs) &&
+          mlir::utils::isZeroTensor(trueVal)) {
+        // case: %in < 0 ? 0 : %in
+        return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
+      }
+      if (mlir::utils::isZeroTensor(cmpLhs) &&
+          mlir::utils::isZeroTensor(falseVal) && cmpRhs == trueVal) {
+        // case: 0 < %in ? %in : 0
+        return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
+      }
+    }
+  }
+  return false;
+}
+
+namespace {
+// Helper matcher functor for relu detection.
+struct WithReluBody {
+  WithReluBody() = delete;
+  WithReluBody(SmallVectorImpl<Value> *captures) : captures(captures){};
+
+  bool operator()(Region *region, Operation *op) {
+    auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+    if (!linalgOp)
+      return false;
+
+    return hasReluBody(linalgOp, captures);
+  }
+
+private:
+  SmallVectorImpl<Value> *captures;
+};
+} // namespace
+
+// Return true if the linalg.generic can be mapped to a tpp.relu.
+bool isTwoDReluOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
+  // clang-format off
+  auto reluMatcher =
+    StructuredOpMatcher::make<linalg::LinalgOp>()
+    .output(MatchAll(), HasMap(Identity()))
+    .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
+    .region(MatchOne(0), WithReluBody(operands));
+  // clang-format on
+  return isTppUnaryOp(linalgOp) && reluMatcher.match(linalgOp);
+}
+
+// // Return true if the linalg.generic can be mapped to a tpp.identity.
+// bool isTwoDIdentityOp(linalg::LinalgOp linalgOp,
+//                       SmallVectorImpl<Value> *operands) {
+//   SmallVector<Value, 2> linalgOperands;
+//   // clang-format off
+//   auto identityMatcher = 
+//     StructuredOpMatcher::make<linalg::LinalgOp>()
+//     .output(MatchAll(), HasMap(Identity()))
+//     .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
+//     .region(
+//       MatchOne(0), WithSingleOp<linalg::YieldOp>(&linalgOperands));
+//   // clang-format on
+
+//   if (!isTppUnaryOp(linalgOp) || !identityMatcher.match(linalgOp) ||
+//       linalgOperands.size() != 2) {
+//     return false;
+//   }
+
+//   if (operands)
+//     operands->append(linalgOperands.begin(), linalgOperands.end());
+
+//   return true;
+// }
+
+// Return true if the linalg.generic can be mapped to a tpp.zero.
+bool isTwoDZeroOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
+  // clang-format off
+  auto zeroMatcher = 
+    StructuredOpMatcher::make<linalg::LinalgOp>()
+    .output(MatchAll(), HasMap(Identity()))
+    .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))
+    .region(MatchOne(0), WithSingleOp<linalg::YieldOp>());
+  // clang-format on
+
+  if (!isTppUnaryOp(linalgOp) || !zeroMatcher.match(linalgOp))
+    return false;
+
+  Operation *yieldOp = linalgOp.getBlock()->getTerminator();
+  if (!mlir::utils::isZeroTensor(yieldOp->getOperand(0)))
+    return false;
+
+  // Only take the output as tpp.zero is an in-place operation.
+  Value output = linalgOp.getDpsInits()[0];
+  if (!isa<ShapedType>(output.getType()))
+    return false;
+
+  if (operands)
+    operands->push_back(output);
+  return true;
+}
+
+// Return true if the linalg.generic can be mapped to a tpp.add + tpp.max.
+// TODO: This will be done at tpp.group level later on
+bool isTwoDBiasReluOp(linalg::LinalgOp linalgOp,
+                      SmallVectorImpl<Value> *operands) {
+  // clang-format off
+  auto biasReluMatcher = 
+    StructuredOpMatcher::make<linalg::LinalgOp>()
+      .region(MatchOne(0), 
+              WithOpChain<arith::AddFOp, arith::MaximumFOp>(operands));
+  // clang-format on
+
+  if (!isTppBinaryOp(linalgOp) || !biasReluMatcher.match(linalgOp))
+    return false;
+
+  // Only take the output as tpp.add + tpp.relu should be in-place operations.
+  Value output = linalgOp.getDpsInits()[0];
+  if (!isa<ShapedType>(output.getType()))
+    return false;
+
+  if (operands)
+    operands->push_back(output);
+  return true;
+}
+
+bool isTwoDTransposeOp(linalg::LinalgOp linalgOp,
+                       SmallVectorImpl<Value> *operands) {
+  // clang-format off
+  auto isTwoDTransposeMatcher = 
+    StructuredOpMatcher::make<linalg::TransposeOp>()
+    .output(MatchAll(), HasRank({2}))
+    .input(MatchAll(), HasRank({2}));
+  // clang-format on 
+  if (!isTppUnaryOp(linalgOp) || !isTwoDTransposeMatcher.match(linalgOp))
+    return false;
+  if (operands) {
+    operands->push_back(linalgOp.getDpsInputs()[0]);
+    operands->push_back(linalgOp.getDpsInits()[0]);
+  }
+  return true;
+}
+
+bool isTwoDFillOpWithZeros(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
+  struct IsZeroValue {
+      IsZeroValue() = default;
+      bool operator()(OpOperand *operand, Operation *operation) {
+        return mlir::utils::isZeroTensor(operand->get());
+      }
+  };
+  
+  // clang-format off
+  auto isTwoDFillOpWithZerosMatcher =
+    StructuredOpMatcher::make<linalg::FillOp>()
+    .input(MatchAll(), IsZeroValue());
+  // clang-format on
+  if (!isTppUnaryOp(linalgOp) || !isTwoDFillOpWithZerosMatcher.match(linalgOp))
+    return false;
+  if (operands) {
+    operands->push_back(linalgOp.getDpsInputs()[0]);
+    operands->push_back(linalgOp.getDpsInits()[0]);
+  }
+  return true;
+}
+
+} // namespace utils
+} // namespace structured_match
+} // namespace mlir

--- a/lib/gc/Transforms/Utils/MatcherUtils.cpp
+++ b/lib/gc/Transforms/Utils/MatcherUtils.cpp
@@ -328,7 +328,7 @@ namespace {
 // Helper matcher functor for relu detection.
 struct WithReluBody {
   WithReluBody() = delete;
-  WithReluBody(SmallVectorImpl<Value> *captures) : captures(captures) {};
+  WithReluBody(SmallVectorImpl<Value> *captures) : captures(captures){};
 
   bool operator()(Region *region, Operation *op) {
     auto linalgOp = dyn_cast<linalg::LinalgOp>(op);

--- a/lib/gc/Transforms/Utils/MatcherUtils.cpp
+++ b/lib/gc/Transforms/Utils/MatcherUtils.cpp
@@ -55,10 +55,10 @@ namespace utils {
 //           .operation(NumOfLoops(_OR(EqualsTo(5), EqualsTo(4))))
 //           .input(MatchAll(), HasStaticShape())
 //           .output(MatchAll(), HasStaticShape())
-//           .input(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &mapOperandA))
-//           .input(MatchOne(1), HasMap(Any(), &mapOperandB))
-//           .output(MatchOne(0), HasMap(BroadcastableProjectedPermutation(), &mapOperandC))
-//           .region(MatchOne(0),
+//           .input(MatchOne(0), HasMap(BroadcastableProjectedPermutation(),
+//           &mapOperandA)) .input(MatchOne(1), HasMap(Any(), &mapOperandB))
+//           .output(MatchOne(0), HasMap(BroadcastableProjectedPermutation(),
+//           &mapOperandC)) .region(MatchOne(0),
 //                   WithOpChain<arith::MulFOp, arith::AddFOp>(operands));
 //   // clang-format on
 //   if (!matmulMatcher.match(linalgOp))
@@ -72,7 +72,8 @@ namespace utils {
 //   int64_t iParIter = operandCPosIterPar[0];
 //   int64_t jParIter = operandCPosIterPar[1];
 
-//   // Operand A: One parallel iterator (i) and two reduction ones (batch and k).
+//   // Operand A: One parallel iterator (i) and two reduction ones (batch and
+//   k).
 //   // The batch dimension is optional.
 //   llvm::SmallVector<int64_t> operandAPosIterPar = getIteratorPos(
 //       linalgOp, mapOperandA, mlir::utils::IteratorType::parallel);
@@ -296,8 +297,7 @@ static bool hasReluBody(Operation *op, SmallVectorImpl<Value> *captured) {
 
     if (cmpPredicate == arith::CmpFPredicate::UGT ||
         cmpPredicate == arith::CmpFPredicate::UGE) {
-      if (cmpLhs == trueVal &&
-          mlir::utils::isZeroTensor(cmpRhs) &&
+      if (cmpLhs == trueVal && mlir::utils::isZeroTensor(cmpRhs) &&
           mlir::utils::isZeroTensor(falseVal)) {
         // case: %in > 0 ? %in : 0
         return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
@@ -309,8 +309,7 @@ static bool hasReluBody(Operation *op, SmallVectorImpl<Value> *captured) {
       }
     } else if (cmpPredicate == arith::CmpFPredicate::ULT ||
                cmpPredicate == arith::CmpFPredicate::ULE) {
-      if (cmpLhs == falseVal &&
-          mlir::utils::isZeroTensor(cmpRhs) &&
+      if (cmpLhs == falseVal && mlir::utils::isZeroTensor(cmpRhs) &&
           mlir::utils::isZeroTensor(trueVal)) {
         // case: %in < 0 ? 0 : %in
         return (getOperand(cmpLhs, cmpRhs) || getOperand(cmpRhs, cmpLhs));
@@ -329,7 +328,7 @@ namespace {
 // Helper matcher functor for relu detection.
 struct WithReluBody {
   WithReluBody() = delete;
-  WithReluBody(SmallVectorImpl<Value> *captures) : captures(captures){};
+  WithReluBody(SmallVectorImpl<Value> *captures) : captures(captures) {};
 
   bool operator()(Region *region, Operation *op) {
     auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
@@ -361,7 +360,7 @@ bool isTwoDReluOp(linalg::LinalgOp linalgOp, SmallVectorImpl<Value> *operands) {
 //                       SmallVectorImpl<Value> *operands) {
 //   SmallVector<Value, 2> linalgOperands;
 //   // clang-format off
-//   auto identityMatcher = 
+//   auto identityMatcher =
 //     StructuredOpMatcher::make<linalg::LinalgOp>()
 //     .output(MatchAll(), HasMap(Identity()))
 //     .input(MatchAll(), HasMap(BroadcastableProjectedPermutation()))

--- a/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
+++ b/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
@@ -1,0 +1,295 @@
+//===- StructuredOpMatcher.cpp -----------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gc/Transforms/Utils/StructuredOpMatcher.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "structured-matchers"
+
+using namespace mlir;
+
+// Entry point.
+bool structured_match::StructuredOpMatcher::match(Operation *op) {
+  auto linalgOp = dyn_cast_or_null<linalg::LinalgOp>(op);
+  if (!linalgOp)
+    return false;
+  LLVM_DEBUG(llvm::dbgs() << "Running matcher on: " << *op << "\n");
+
+  for (auto [idx, predicate] : llvm::enumerate(predicates)) {
+    if (!predicate(linalgOp)) {
+      LLVM_DEBUG(llvm::dbgs() << "Exit on predicate: " << idx << "\n");
+      return false;
+    }
+  }
+  return true;
+}
+
+//===---------------------------------------------------------------------===//
+// Operation predicates.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::operation(
+    std::function<bool(Operation *op)> fun) {
+  predicates.push_back(
+      [=](linalg::LinalgOp linalgOp) -> bool { return fun(linalgOp); });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Operand predicates - input.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::input(
+    MatchSelector range,
+    std::function<bool(OpOperand *operand, Operation *op)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    auto operands = linalgOp.getDpsInputOperands();
+    size_t upperBound = range.getUpperBound();
+    size_t lowerBound = range.getLowerBound();
+    if (upperBound == std::numeric_limits<size_t>::max())
+      upperBound = operands.size();
+
+    for (auto idx :
+         llvm::to_vector(llvm::seq<size_t>(lowerBound, upperBound))) {
+      if (!fun(operands[idx], linalgOp.getOperation()))
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Operand predicates - output.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::output(
+    MatchSelector range,
+    std::function<bool(OpOperand *operand, Operation *operation)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    auto operands = linalgOp.getDpsInitsMutable();
+    size_t upperBound = range.getUpperBound();
+    size_t lowerBound = range.getLowerBound();
+    if (upperBound == std::numeric_limits<size_t>::max())
+      upperBound = operands.size();
+
+    for (auto idx :
+         llvm::to_vector(llvm::seq<size_t>(lowerBound, upperBound))) {
+      if (!fun(&operands[idx], linalgOp.getOperation()))
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Dim predicates.
+//===---------------------------------------------------------------------===//
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::dim(
+    MatchSelector range, SmallVector<utils::IteratorType> kinds) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    size_t upperBound = range.getUpperBound();
+    size_t lowerBound = range.getLowerBound();
+    if (upperBound == std::numeric_limits<size_t>::max())
+      upperBound = kinds.size();
+    size_t sizeRange = upperBound - lowerBound;
+
+    auto iteratorTypes = linalgOp.getIteratorTypesArray();
+    if (iteratorTypes.size() < sizeRange)
+      return false;
+
+    // Reverse iterators to have the innermost one at index 0.
+    std::reverse(iteratorTypes.begin(), iteratorTypes.end());
+    for (auto [idx, rangeIdx] :
+         llvm::enumerate(llvm::seq<size_t>(lowerBound, upperBound))) {
+      if (iteratorTypes[rangeIdx] != kinds[idx])
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::dim(MatchSelector range,
+                                           utils::IteratorType kind) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    auto iteratorTypes = linalgOp.getIteratorTypesArray();
+    size_t upperBound = range.getUpperBound();
+    size_t lowerBound = range.getLowerBound();
+    if (upperBound == std::numeric_limits<size_t>::max())
+      upperBound = iteratorTypes.size();
+
+    for (auto rangeIdx = lowerBound; rangeIdx < upperBound; rangeIdx++) {
+      if (iteratorTypes[rangeIdx] != kind)
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// Region predicates.
+//===---------------------------------------------------------------------===//
+
+bool mlir::structured_match::WithSingleOpImpl::withSingleOpImpl(
+    StringRef operationName, Region *region, Operation *op,
+    SmallVectorImpl<Value> *capturedOperands) {
+  if (!isa<linalg::LinalgOp>(op))
+    return false;
+  auto linalgOp = cast<linalg::LinalgOp>(op);
+
+  if (!region->hasOneBlock())
+    return false;
+  unsigned numberOfOpsInRegion =
+      (operationName.compare(linalg::YieldOp::getOperationName()) == 0) ? 1 : 2;
+  if (std::distance(region->front().begin(), region->front().end()) !=
+      numberOfOpsInRegion)
+    return false;
+  if (linalgOp.getNumDpsInits() != 1)
+    return false;
+
+  // Require only a single yield operand defined by innerOp.
+  Operation *yieldOp = linalgOp.getBlock()->getTerminator();
+  if (yieldOp->getNumOperands() != 1)
+    return false;
+  // Only linalg.yield, exit true.
+  if (numberOfOpsInRegion == 1) {
+    if (capturedOperands) {
+      auto arg0 = dyn_cast<BlockArgument>(yieldOp->getOperand(0));
+      // linalg.yield operand might be coming from a different region.
+      if (arg0 && arg0.getParentBlock() == linalgOp.getBlock())
+        capturedOperands->push_back(linalgOp.getMatchingOpOperand(arg0)->get());
+      capturedOperands->push_back(linalgOp.getDpsInitOperand(0)->get());
+    }
+    return true;
+  }
+
+  // Check on the only inner operation.
+  Operation *innerOp = &(*linalgOp.getBlock()->getOperations().begin());
+  if (innerOp->getName().getStringRef() != operationName)
+    return false;
+  if (yieldOp->getOperand(0).getDefiningOp() != innerOp)
+    return false;
+  // The operand of the innerOp must comes from the region
+  // args of the generic.
+  auto arg0 = dyn_cast<BlockArgument>(innerOp->getOperand(0));
+  auto arg1 = dyn_cast<BlockArgument>(innerOp->getOperand(1));
+  if (!arg0 || !arg1)
+    return false;
+  if (arg0.getParentBlock() != linalgOp.getBlock() ||
+      arg1.getParentBlock() != linalgOp.getBlock())
+    return false;
+  if (capturedOperands) {
+    capturedOperands->push_back(linalgOp.getMatchingOpOperand(arg0)->get());
+    capturedOperands->push_back(linalgOp.getMatchingOpOperand(arg1)->get());
+    capturedOperands->push_back(linalgOp.getDpsInitOperand(0)->get());
+  }
+  return true;
+}
+
+// FIXME: This is a generalization of the method above and will eventually
+// replace the matcher for both no-op (yield) and one op (add, max).
+bool mlir::structured_match::withOpChainImpl(
+    Region *region, Operation *op, SmallVectorImpl<Value> *capturedOperands,
+    SmallVectorImpl<TypeCheckFunc> &typeChecks) {
+
+  // Number of ops includes yield
+  ptrdiff_t numOps = typeChecks.size() + 1;
+
+  // Basic checks
+  if (!isa<linalg::LinalgOp>(op))
+    return false;
+  auto linalgOp = cast<linalg::LinalgOp>(op);
+  if (!region->hasOneBlock())
+    return false;
+  auto &block = region->front();
+  if (std::distance(block.begin(), block.end()) != numOps)
+    return false;
+  if (linalgOp.getNumDpsInits() != 1)
+    return false;
+
+  // Add generic arguments to the list of chained values
+  llvm::SmallSetVector<Value, 4> chainedValues;
+  for (auto arg : block.getArguments()) {
+    chainedValues.insert(arg);
+  }
+
+  // Check on the inner chain of operations in the right order.
+  // Make sure all operands are used and chained
+  for (auto [check, innerOp] :
+       llvm::zip_first(typeChecks, block.getOperations())) {
+    // Must be right op in right order
+    if (!check(&innerOp))
+      return false;
+
+    // At least one operand must come from args or a previous op
+    bool consumesValueFromChain = false;
+    for (auto operand : innerOp.getOperands()) {
+      if (chainedValues.contains(operand)) {
+        // First add to the captured
+        auto ba = dyn_cast<BlockArgument>(operand);
+        if (capturedOperands && ba &&
+            ba.getParentBlock() == linalgOp.getBlock()) {
+          capturedOperands->push_back(linalgOp.getMatchingOpOperand(ba)->get());
+        }
+        // Then erase from the set
+        chainedValues.remove(operand);
+        consumesValueFromChain = true;
+      }
+    }
+
+    // Operation isn't in the chain
+    if (!consumesValueFromChain)
+      return false;
+
+    // Add return value to the list of chained values
+    for (auto ret : innerOp.getResults()) {
+      chainedValues.insert(ret);
+    }
+  }
+
+  // Last op must be a chained yield.
+  Operation *yieldOp = linalgOp.getBlock()->getTerminator();
+  assert(isa<linalg::YieldOp>(yieldOp) && "Wrong terminator");
+  for (auto op : yieldOp->getOperands()) {
+    if (!chainedValues.contains(op))
+      return false;
+  }
+
+  return true;
+}
+
+structured_match::StructuredOpMatcher &
+structured_match::StructuredOpMatcher::region(
+    MatchSelector range,
+    std::function<bool(Region *region, Operation *op)> fun) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    auto regions = linalgOp->getRegions();
+    assert(regions.size() != 0);
+    size_t upperBound = range.getUpperBound();
+    size_t lowerBound = range.getLowerBound();
+    if (upperBound == std::numeric_limits<size_t>::max())
+      upperBound = regions.size();
+
+    for (auto idx :
+         llvm::to_vector(llvm::seq<size_t>(lowerBound, upperBound))) {
+      if (!fun(&regions[idx], linalgOp.getOperation()))
+        return false;
+    }
+    return true;
+  });
+  return *this;
+}

--- a/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
+++ b/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
@@ -20,12 +20,14 @@ bool structured_match::StructuredOpMatcher::match(Operation *op) {
     return false;
   LLVM_DEBUG(llvm::dbgs() << "Running matcher on: " << *op << "\n");
 
+  // NOLINTBEGIN
   for (auto [idx, predicate] : llvm::enumerate(predicates)) {
     if (!predicate(linalgOp)) {
       LLVM_DEBUG(llvm::dbgs() << "Exit on predicate: " << idx << "\n");
       return false;
     }
   }
+  // NOLINTEND
   return true;
 }
 
@@ -35,7 +37,7 @@ bool structured_match::StructuredOpMatcher::match(Operation *op) {
 
 structured_match::StructuredOpMatcher &
 structured_match::StructuredOpMatcher::operation(
-    std::function<bool(Operation *op)> fun) {
+    std::function<bool(Operation *op)> fun) { // NOLINT
   predicates.push_back(
       [=](linalg::LinalgOp linalgOp) -> bool { return fun(linalgOp); });
   return *this;
@@ -48,7 +50,7 @@ structured_match::StructuredOpMatcher::operation(
 structured_match::StructuredOpMatcher &
 structured_match::StructuredOpMatcher::input(
     MatchSelector range,
-    std::function<bool(OpOperand *operand, Operation *op)> fun) {
+    std::function<bool(OpOperand *operand, Operation *op)> fun) { // NOLINT
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     auto operands = linalgOp.getDpsInputOperands();
     size_t upperBound = range.getUpperBound();
@@ -73,7 +75,8 @@ structured_match::StructuredOpMatcher::input(
 structured_match::StructuredOpMatcher &
 structured_match::StructuredOpMatcher::output(
     MatchSelector range,
-    std::function<bool(OpOperand *operand, Operation *operation)> fun) {
+    std::function<bool(OpOperand *operand, Operation *operation)>
+        fun) { // NOLINT
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     auto operands = linalgOp.getDpsInitsMutable();
     size_t upperBound = range.getUpperBound();
@@ -97,7 +100,7 @@ structured_match::StructuredOpMatcher::output(
 
 structured_match::StructuredOpMatcher &
 structured_match::StructuredOpMatcher::dim(
-    MatchSelector range, SmallVector<utils::IteratorType> kinds) {
+    MatchSelector range, SmallVector<utils::IteratorType> kinds) { // NOLINT
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     size_t upperBound = range.getUpperBound();
     size_t lowerBound = range.getLowerBound();
@@ -262,12 +265,14 @@ bool mlir::structured_match::withOpChainImpl(
   }
 
   // Last op must be a chained yield.
+  // NOLINTBEGIN
   Operation *yieldOp = linalgOp.getBlock()->getTerminator();
   assert(isa<linalg::YieldOp>(yieldOp) && "Wrong terminator");
   for (auto op : yieldOp->getOperands()) {
     if (!chainedValues.contains(op))
       return false;
   }
+  // NOLINTEND
 
   return true;
 }
@@ -275,10 +280,10 @@ bool mlir::structured_match::withOpChainImpl(
 structured_match::StructuredOpMatcher &
 structured_match::StructuredOpMatcher::region(
     MatchSelector range,
-    std::function<bool(Region *region, Operation *op)> fun) {
+    std::function<bool(Region *region, Operation *op)> fun) { // NOLINT
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     auto regions = linalgOp->getRegions();
-    assert(regions.size() != 0);
+    assert(regions.size() != 0); // NOLINT
     size_t upperBound = range.getUpperBound();
     size_t lowerBound = range.getLowerBound();
     if (upperBound == std::numeric_limits<size_t>::max())

--- a/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
+++ b/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
@@ -1,6 +1,6 @@
-//===- StructuredOpMatcher.cpp -----------------------------------*- C++-*-===//
+//===- StructuredOpMatcher.cpp -----------------------------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
+++ b/lib/gc/Transforms/Utils/StructuredOpMatcher.cpp
@@ -1,4 +1,4 @@
-//===- StructuredOpMatcher.cpp -----------------------------------*- C++ -*-===//
+//===- StructuredOpMatcher.cpp - Structured op matcher ----------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Transforms/Utils/ValueUtils.cpp
+++ b/lib/gc/Transforms/Utils/ValueUtils.cpp
@@ -1,4 +1,4 @@
-//===- ValueUtils.cpp -------------------------------------------*- C++ -*-===//
+//===-- ValueUtils.cpp - Zero-checking utilities ----------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Transforms/Utils/ValueUtils.cpp
+++ b/lib/gc/Transforms/Utils/ValueUtils.cpp
@@ -1,0 +1,120 @@
+//===- ValueUtils.cpp --------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/Value.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace mlir {
+namespace utils {
+
+// Returns true if the value is a constant float or integer.
+bool isValConstZero(Value val) {
+  return matchPattern(val, m_AnyZeroFloat()) || matchPattern(val, m_Zero());
+}
+
+// Returns true if the attribute represent "all zeros"
+static bool isZeroAttr(Attribute attribute) {
+  return TypeSwitch<Attribute, bool>(attribute)
+      .Case<FloatAttr>([](auto attr) { return attr.getValueAsDouble() == 0.0; })
+      .Case<IntegerAttr>([](auto attr) { return attr.getInt() == 0; })
+      .Case<DenseElementsAttr>([](auto attr) {
+        if (!attr.getElementType().isIntOrFloat())
+          return false;
+        if (!attr.isSplat())
+          return false;
+        auto splat = attr.template getSplatValue<Attribute>();
+        return isZeroAttr(splat);
+      })
+      .Default([](auto attr) { return false; });
+}
+
+// Prototypes
+static bool isZeroOp(Operation *);
+
+// Returns true if the value represents a zero filled tensor.
+// Recurse into isZeroOp for defining ops if not immediately obvious
+// Looks past linalg generic's argument (which don't have defining ops)
+bool isZeroTensor(Value val) {
+  if (!val)
+    return false;
+  if (isValConstZero(val))
+    return true;
+
+  Operation *defOp = nullptr;
+
+  // Block arguments don't have a defining op, but they do have an op arg
+  if (auto arg = dyn_cast<BlockArgument>(val)) {
+    // We need to find the argument to the linalg on the same order as this one
+    auto *linalgOp = arg.getParentRegion()->getParentOp();
+    if (!isa<linalg::GenericOp>(linalgOp))
+      return false;
+    auto index = arg.getArgNumber();
+    auto linalgArg = linalgOp->getOperand(index);
+    defOp = linalgArg.getDefiningOp();
+  } else {
+    defOp = val.getDefiningOp();
+  }
+  return isZeroOp(defOp);
+}
+
+// Returns true if the operation represents a zero filled tensor
+// Recurses into isZeroTensor for operands and isZeroAttr for attributes
+static bool isZeroOp(Operation *defOp) {
+  if (!defOp)
+    return false;
+
+  return TypeSwitch<Operation *, bool>(defOp)
+      .Case<arith::ConstantOp>([&](auto op) {
+        // Dense attributes don't match APFloat.isZero()
+        auto attr = op.getValue();
+        return isZeroAttr(attr);
+      })
+      .Case<linalg::FillOp, linalg::CopyOp>([&](auto op) {
+        if (op.getInputs().size() != 1)
+          return false;
+        return isZeroTensor(op.getInputs()[0]);
+      })
+      .Case<memref::CopyOp, memref::SubViewOp, tensor::CastOp,
+            tensor::ExtractSliceOp>(
+          [&](auto op) { return isZeroTensor(op.getSource()); })
+      .Case<memref::GetGlobalOp>([&](auto op) {
+        auto name = op.getName();
+        auto module = defOp->getParentOfType<ModuleOp>();
+        auto global = module.lookupSymbol<memref::GlobalOp>(name);
+        auto attr = global.getInitialValueAttr();
+        return isZeroAttr(attr);
+      })
+      .Default([&](Operation *op) { return false; });
+}
+
+FailureOr<SmallVector<int64_t>> getStaticStrides(Value value) {
+  auto valueType = value.getType();
+  if (!isa<MemRefType>(valueType))
+    return failure();
+  auto memrefType = cast<MemRefType>(valueType);
+  SmallVector<int64_t> strides;
+  int64_t offset;
+  if (failed(getStridesAndOffset(memrefType, strides, offset))) {
+    return failure();
+  }
+  if (llvm::any_of(strides, [](int64_t stride) {
+        return stride == ShapedType::kDynamic;
+      })) {
+    return failure();
+  }
+  return strides;
+}
+
+} // namespace utils
+} // namespace mlir

--- a/lib/gc/Transforms/Utils/ValueUtils.cpp
+++ b/lib/gc/Transforms/Utils/ValueUtils.cpp
@@ -1,6 +1,6 @@
-//===- ValueUtils.cpp --------------------------------------------*- C++-*-===//
+//===- ValueUtils.cpp -------------------------------------------*- C++ -*-===//
 //
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //

--- a/src/gc-opt/CMakeLists.txt
+++ b/src/gc-opt/CMakeLists.txt
@@ -1,3 +1,20 @@
+################################################################################
+# Copyright (C) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
 if(GC_DEV_LINK_LLVM_DYLIB)
   set(MLIR_LINK_COMPONENTS
     MLIR

--- a/src/gc-opt/CMakeLists.txt
+++ b/src/gc-opt/CMakeLists.txt
@@ -16,7 +16,8 @@ set(gc_opt_libs
         ${dialect_libs}
         ${conversion_libs} 
         ${MLIR_LINK_COMPONENTS}
-        GCPasses)
+        GCPasses
+        GCGPUPasses)
 
 if(GC_MLIR_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GC_MLIR_CXX_FLAGS}")

--- a/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu-dpas.mlir
+++ b/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu-dpas.mlir
@@ -1,0 +1,87 @@
+// RUN: gc-opt %s -linalg-to-xegpu="dpas-tile=8,16,16 k-tile=16" -canonicalize -split-input-file | FileCheck %s
+
+func.func @matmul(%arg0: memref<32x32xf16>, %arg1: memref<32x32xf16>, %arg2: memref<32x32xf16>) {
+  %c1 = arith.constant 1 : index
+  gpu.launch blocks(%arg3, %arg4, %arg5) in (%arg9 = %c1, %arg10 = %c1, %arg11 = %c1) threads(%arg6, %arg7, %arg8) in (%arg12 = %c1, %arg13 = %c1, %arg14 = %c1) {
+    linalg.matmul ins(%arg0, %arg1 : memref<32x32xf16>, memref<32x32xf16>)
+                  outs(%arg2 : memref<32x32xf16>)
+    gpu.terminator
+  }
+  return
+}
+
+// CHECK-LABEL: func.func @matmul
+// CHECK-SAME:  %[[A:.+]]: memref<32x32xf16>, %[[B:.+]]: memref<32x32xf16>, %[[C:.+]]: memref<32x32xf16>
+// CHECK-DAG: %[[c0:.+]] = arith.constant 0
+// CHECK-DAG: %[[c16:.+]] = arith.constant 16
+// CHECK-DAG: %[[c32:.+]] = arith.constant 32
+
+// Create output initial value load tiles.
+// CHECK: %[[rootC:.+]] = xegpu.create_nd_tdesc %[[C]]
+// CHECK: %[[tC:.+]] = xegpu.update_nd_offset %[[rootC]], [0, 0]
+// CHECK-COUNT-7: xegpu.update_nd_offset %[[rootC]]
+
+// Load initial accumulator values.
+// CHECK: %[[vC:.+]] = xegpu.load_nd %[[tC]]
+// CHECK-COUNT-7: xegpu.load_nd
+
+// Extend the type to match DPAS output precision.
+// CHECK: %[[vC_f32:.+]] = arith.extf %[[vC]]
+// CHECK-COUNT-7: arith.extf
+
+// Create input load tiles.
+// CHECK: %[[rootA:.+]] = xegpu.create_nd_tdesc %[[A]]
+// CHECK: %[[tA:.+]] = xegpu.update_nd_offset %[[rootA]], [0, 0]
+// CHECK: %[[rootB:.+]] = xegpu.create_nd_tdesc %[[B]]
+// CHECK: %[[tB:.+]] = xegpu.update_nd_offset %[[rootB]], [0, 0]
+// CHECK-COUNT-1: xegpu.update_nd_offset %[[rootB]]
+
+// Create DPAS computation loop over tiled reduction dimension.
+// CHECK: %[[res:.+]]:11 = scf.for{{.*}}%[[c0]] to %[[c32]] step %[[c16]]
+// CHECK-SAME: iter_args(%[[acc:.+]] = %[[vC_f32]],{{.*}}%[[iterA:.+]] = %[[tA]],{{.*}}%[[iterB:.+]] = %[[tB]]
+// CHECK-SAME: {
+
+// Periodically synchronize the workgroup.
+// CHECK: scf.if
+// CHECK-SAME: {
+// CHECK:   gpu.barrier
+// CHECK: }
+
+// Load input values and update the load tile position.
+// CHECK:   %[[vA:.+]] = xegpu.load_nd %[[iterA]]
+// CHECK:   %[[vB:.+]] = xegpu.load_nd %[[iterB]]
+// CHECK-COUNT-1: xegpu.load_nd
+// CHECK:   %[[new_tA:.+]] = xegpu.update_nd_offset %[[iterA]]
+// CHECK:   %[[new_tB:.+]] = xegpu.update_nd_offset %[[iterB]]
+// CHECK-COUNT-1: xegpu.update_nd_offset
+
+// Apply simple prefetching scheme - start loading the next set of input
+// tiles before computation is started.
+// CHECK:   xegpu.prefetch_nd %[[new_tA]]
+// CHECK:   xegpu.prefetch_nd %[[new_tB]]
+// CHECK-COUNT-1: xegpu.prefetch_nd
+
+// Extract DPAS-sized chunks from larger loaded tile A.
+// Tile B is already in the correct shape.
+// CHECK:   %[[vA_flat:.+]] = vector.shape_cast %[[vA]] : vector<32x8x2xf16> to vector<512xf16>
+// CHECK:   %[[vA_dpas_flat:.+]] = vector.extract_strided_slice{{.*}}: vector<512xf16> to vector<128xf16>
+// CHECK:   %[[vA_dpas:.+]] = vector.shape_cast %[[vA_dpas_flat]] : vector<128xf16> to vector<8x8x2xf16>
+// CHECK-COUNT-3: vector.extract_strided_slice
+
+// Perform DPAS computation.
+// CHECK:   %[[dpas:.+]] = xegpu.dpas %[[vA_dpas]], %[[vB]], %[[acc]]
+// CHECK-COUNT-7: xegpu.dpas
+
+// Yield the results to the next iteration.
+// CHECK:   scf.yield %[[dpas]],{{.*}}%[[new_tA]],{{.*}}%[[new_tB]]
+// CHECK: }
+
+// Truncate results to the original output precision.
+// CHECK: %[[res_f16:.+]] = arith.truncf %[[res]]#0
+// CHECK-COUNT-7: arith.truncf
+
+// Store back the final results.
+// CHECH: xegpu.store_nd %[[res_f16]], %[[tC]]
+// CHECK-COUNT-7: xegpu.store_nd
+
+// CHECK: gpu.terminator

--- a/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu-stages.mlir
+++ b/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu-stages.mlir
@@ -1,0 +1,53 @@
+// RUN: gc-opt %s -linalg-to-xegpu="dpas-tile=8,16,16 stages=1" -canonicalize -split-input-file | FileCheck %s --check-prefix=STAGES-1
+
+// RUN: gc-opt %s -linalg-to-xegpu="dpas-tile=8,16,16 stages=2" -canonicalize -split-input-file | FileCheck %s --check-prefix=STAGES-2
+
+#map = affine_map<()[s0, s1] -> (s0 + s1)>
+module {
+  func.func @matmul_multistage_coop_prefetch(%arg0: memref<1024x1024xf16>, %arg1: memref<1024x1024xf16>, %arg2: memref<1024x1024xf16>) {
+    %c32 = arith.constant 32 : index
+    %c0 = arith.constant 0 : index
+    %c1024 = arith.constant 1024 : index
+    %c128 = arith.constant 128 : index
+    scf.parallel (%arg3, %arg4) = (%c0, %c0) to (%c1024, %c1024) step (%c128, %c128) {
+      %subview = memref.subview %arg2[%arg3, %arg4] [128, 128] [1, 1] : memref<1024x1024xf16> to memref<128x128xf16, strided<[1024, 1], offset: ?>>
+      scf.parallel (%arg5, %arg6) = (%c0, %c0) to (%c128, %c128) step (%c32, %c32) {
+        %subview_0 = memref.subview %subview[%arg5, %arg6] [32, 32] [1, 1] : memref<128x128xf16, strided<[1024, 1], offset: ?>> to memref<32x32xf16, strided<[1024, 1], offset: ?>>
+        %0 = affine.apply #map()[%arg5, %arg3]
+        %subview_1 = memref.subview %arg0[%0, 0] [32, 1024] [1, 1] : memref<1024x1024xf16> to memref<32x1024xf16, strided<[1024, 1], offset: ?>>
+        %1 = affine.apply #map()[%arg6, %arg4]
+        %subview_2 = memref.subview %arg1[0, %1] [1024, 32] [1, 1] : memref<1024x1024xf16> to memref<1024x32xf16, strided<[1024, 1], offset: ?>>
+        linalg.matmul ins(%subview_1, %subview_2 : memref<32x1024xf16, strided<[1024, 1], offset: ?>>, memref<1024x32xf16, strided<[1024, 1], offset: ?>>) outs(%subview_0 : memref<32x32xf16, strided<[1024, 1], offset: ?>>)
+        scf.reduce 
+      }
+      scf.reduce 
+    }
+    return
+  }
+}
+
+// STAGES-1-LABEL: func.func @matmul_multistage_coop_prefetch
+// STAGES-1-SAME:  %[[A:.+]]: memref<1024x1024xf16>, %[[B:.+]]: memref<1024x1024xf16>, %[[C:.+]]: memref<1024x1024xf16>
+// STAGES-1: %[[s1_A:.+]] = xegpu.create_nd_tdesc %[[A]]
+// STAGES-1: %[[s1_B:.+]] = xegpu.create_nd_tdesc %[[B]]
+// STAGES-1: xegpu.prefetch_nd %[[s1_A]]
+// STAGES-1: xegpu.prefetch_nd %[[s1_B]]
+// STAGES-1: %[[loop_pref_A:.+]] = xegpu.update_nd_offset %[[s1_A]]
+// STAGES-1: %[[loop_pref_B:.+]] = xegpu.update_nd_offset %[[s1_B]]
+// STAGES-1-NOT: xegpu.prefetch_nd
+// STAGES-1: scf.for
+
+// STAGES-2-LABEL: func.func @matmul_multistage_coop_prefetch
+// STAGES-2-SAME:  %[[A:.+]]: memref<1024x1024xf16>, %[[B:.+]]: memref<1024x1024xf16>, %[[C:.+]]: memref<1024x1024xf16>
+// STAGES-2: %[[s1_A:.+]] = xegpu.create_nd_tdesc %[[A]]
+// STAGES-2: %[[s1_B:.+]] = xegpu.create_nd_tdesc %[[B]]
+// STAGES-2: xegpu.prefetch_nd %[[s1_A]]
+// STAGES-2: xegpu.prefetch_nd %[[s1_B]]
+// STAGES-2: %[[s2_A:.+]] = xegpu.update_nd_offset %[[s1_A]]
+// STAGES-2: %[[s2_B:.+]] = xegpu.update_nd_offset %[[s1_B]]
+// STAGES-2: xegpu.prefetch_nd %[[s2_A]]
+// STAGES-2: xegpu.prefetch_nd %[[s2_B]]
+// STAGES-2: %[[loop_pref_A:.+]] = xegpu.update_nd_offset %[[s2_A]]
+// STAGES-2: %[[loop_pref_B:.+]] = xegpu.update_nd_offset %[[s2_B]]
+// STAGES-2-NOT: xegpu.prefetch_nd
+// STAGES-2: scf.for

--- a/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu.mlir
+++ b/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu.mlir
@@ -1,0 +1,217 @@
+// RUN: gc-opt %s -linalg-to-xegpu="dpas-tile=8,16,16 k-tile=16" -canonicalize -split-input-file | FileCheck %s
+
+func.func @matmul(%arg0: memref<8x16xf16>, %arg1: memref<16x16xf16>, %arg2: memref<8x16xf32>) {
+  linalg.matmul ins(%arg0, %arg1 : memref<8x16xf16>, memref<16x16xf16>)
+                outs(%arg2 : memref<8x16xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul
+// CHECK-COUNT-3: xegpu.load_nd
+// CHECK: xegpu.dpas
+// CHECH: xegpu.store_nd
+
+// -----
+
+#map = affine_map<(d0, d1, d2) -> (d0, d2)>
+#map1 = affine_map<(d0, d1, d2) -> (d2, d1)>
+#map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
+module {
+  func.func @generic_matmul(%arg0: memref<8x16xf16>, %arg1: memref<16x16xf16>, %arg2: memref<8x16xf16>) {
+    linalg.generic {indexing_maps = [#map, #map1, #map2], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0, %arg1 : memref<8x16xf16>, memref<16x16xf16>) outs(%arg2 : memref<8x16xf16>) {
+    ^bb0(%in: f16, %in_0: f16, %out: f16):
+      %0 = arith.mulf %in, %in_0 : f16
+      %1 = arith.addf %out, %0 : f16
+      linalg.yield %1 : f16
+    }
+    return
+  }
+}
+
+// CHECK-LABEL: func.func @generic_matmul
+// CHECK-COUNT-3: xegpu.load_nd
+// CHECK: xegpu.dpas
+// CHECH: xegpu.store_nd
+
+// -----
+
+func.func @matmul_trunc_result(%arg0: memref<8x16xf16>, %arg1: memref<16x16xf16>, %arg2: memref<8x16xf16>) {
+  linalg.matmul ins(%arg0, %arg1 : memref<8x16xf16>, memref<16x16xf16>)
+                outs(%arg2 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @matmul_trunc_result
+// CHECK: arith.extf
+// CHECK: xegpu.dpas
+// CHECK: arith.truncf
+// CHECH: xegpu.store_nd
+
+// -----
+
+func.func @abs(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>) {
+  linalg.abs ins(%arg0 : memref<8x16xf16>)
+             outs(%arg1 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @abs
+// CHECK-COUNT-1: xegpu.load_nd
+// CHECK: math.absf
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @add(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>, %arg2: memref<8x16xf16>) {
+  linalg.add ins(%arg0, %arg1 : memref<8x16xf16>, memref<8x16xf16>)
+             outs(%arg2 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @add
+// CHECK-COUNT-2: xegpu.load_nd
+// CHECK: arith.addf
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @ceil(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>) {
+  linalg.ceil ins(%arg0 : memref<8x16xf16>)
+              outs(%arg1 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @ceil
+// CHECK-COUNT-1: xegpu.load_nd
+// CHECK: math.ceil
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @div(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>, %arg2: memref<8x16xf16>) {
+  linalg.div ins(%arg0, %arg1 : memref<8x16xf16>, memref<8x16xf16>)
+             outs(%arg2 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @div
+// CHECK-COUNT-2: xegpu.load_nd
+// CHECK: arith.divf
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @div_unsigned(%arg0: memref<8x16xi16>, %arg1: memref<8x16xi16>, %arg2: memref<8x16xi16>) {
+  linalg.div_unsigned ins(%arg0, %arg1 : memref<8x16xi16>, memref<8x16xi16>)
+                      outs(%arg2 : memref<8x16xi16>)
+  return
+}
+
+// CHECK-LABEL: func.func @div_unsigned
+// CHECK-COUNT-2: xegpu.load_nd
+// CHECK: arith.divui
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @exp(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>) {
+  linalg.exp ins(%arg0 : memref<8x16xf16>)
+             outs(%arg1 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @exp
+// CHECK-COUNT-1: xegpu.load_nd
+// CHECK: math.exp
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @floor(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>) {
+  linalg.floor ins(%arg0 : memref<8x16xf16>)
+               outs(%arg1 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @floor
+// CHECK-COUNT-1: xegpu.load_nd
+// CHECK: math.floor
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @max(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>, %arg2: memref<8x16xf16>) {
+  linalg.max ins(%arg0, %arg1 : memref<8x16xf16>, memref<8x16xf16>)
+             outs(%arg2 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @max
+// CHECK-COUNT-2: xegpu.load_nd
+// CHECK: arith.maximumf
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @mul(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>, %arg2: memref<8x16xf16>) {
+  linalg.mul ins(%arg0, %arg1 : memref<8x16xf16>, memref<8x16xf16>)
+             outs(%arg2 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @mul
+// CHECK-COUNT-2: xegpu.load_nd
+// CHECK: arith.mulf
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @negf(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>) {
+  linalg.negf ins(%arg0 : memref<8x16xf16>)
+              outs(%arg1 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @negf
+// CHECK-COUNT-1: xegpu.load_nd
+// CHECK: arith.negf
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @sub(%arg0: memref<8x16xf16>, %arg1: memref<8x16xf16>, %arg2: memref<8x16xf16>) {
+  linalg.sub ins(%arg0, %arg1 : memref<8x16xf16>, memref<8x16xf16>)
+             outs(%arg2 : memref<8x16xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @sub
+// CHECK-COUNT-2: xegpu.load_nd
+// CHECK: arith.subf
+// CHECK: xegpu.store_nd
+
+// -----
+
+func.func @add_large_f16(%arg0: memref<64x64xf16>, %arg1: memref<64x64xf16>, %arg2: memref<64x64xf16>) {
+  linalg.add ins(%arg0, %arg1 : memref<64x64xf16>, memref<64x64xf16>)
+             outs(%arg2 : memref<64x64xf16>)
+  return
+}
+
+// CHECK-LABEL: func.func @add_large_f16
+// CHECK: xegpu.load_nd{{.*}}: !xegpu.tensor_desc<32x32xf16{{.*}}> -> vector<32x32xf16>
+// CHECK: arith.addf{{.*}}: vector<8x32xf16>
+// CHECK: xegpu.store_nd{{.*}}: vector<8x32xf16>
+
+// -----
+
+func.func @add_large_f32(%arg0: memref<64x64xf32>, %arg1: memref<64x64xf32>, %arg2: memref<64x64xf32>) {
+  linalg.add ins(%arg0, %arg1 : memref<64x64xf32>, memref<64x64xf32>)
+             outs(%arg2 : memref<64x64xf32>)
+  return
+}
+
+// CHECK-LABEL: func.func @add_large_f32
+// CHECK: xegpu.load_nd{{.*}}: !xegpu.tensor_desc<32x16xf32{{.*}}> -> vector<32x16xf32>
+// CHECK: arith.addf{{.*}}: vector<16x16xf32>
+// CHECK: xegpu.store_nd{{.*}}: vector<16x16xf32>


### PR DESCRIPTION
Closes #160

This PR copies `LinalgToXeGPU` pass from [tpp-mlir project](https://github.com/plaidml/tpp-mlir/blob/main/lib/TPP/GPU/LinalgToXeGPU.cpp), conversion tests, and a few files with utilities that are used by `LinalgToXeGPU.cpp` (unused utilities were removed from these files).

Things to do:
- [ ] Try to remove dependency on `StructuredOpMatcher.cpp`
