### PR TITLE
Fix gc-cpu-runner arith dialect parsing failure

### DIFF
--- a/src/gc-cpu-runner/gc-cpu-runner.cpp
+++ b/src/gc-cpu-runner/gc-cpu-runner.cpp
@@ -21,6 +21,7 @@
 #include "mlir/ExecutionEngine/JitRunner.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/InitAllDialects.h"
 #include "mlir/Target/LLVMIR/Dialect/All.h"
 
 #include "llvm/Support/InitLLVM.h"
@@ -38,6 +39,7 @@ int main(int argc, char **argv) {
   llvm::InitializeNativeTargetAsmParser();
 
   mlir::DialectRegistry registry;
+  mlir::registerAllDialects(registry);
   mlir::registerAllToLLVMIRTranslations(registry);
 
   return mlir::JitRunnerMain(argc, argv, registry);

--- a/src/gc-cpu-runner/gc-cpu-runner.cpp
+++ b/src/gc-cpu-runner/gc-cpu-runner.cpp
@@ -17,11 +17,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/ExecutionEngine/JitRunner.h"
 #include "mlir/ExecutionEngine/OptUtils.h"
 #include "mlir/IR/Dialect.h"
-#include "mlir/InitAllDialects.h"
 #include "mlir/Target/LLVMIR/Dialect/All.h"
 
 #include "llvm/Support/InitLLVM.h"
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
   llvm::InitializeNativeTargetAsmParser();
 
   mlir::DialectRegistry registry;
-  mlir::registerAllDialects(registry);
+  registry.insert<mlir::arith::ArithDialect>();
   mlir::registerAllToLLVMIRTranslations(registry);
 
   return mlir::JitRunnerMain(argc, argv, registry);


### PR DESCRIPTION
Fix gc-cpu-runner parser stage error on bf16 workloads
```
loc("<stdin>":83:53): error: #"arith"<"fastmath<contract>"> : 'none' attribute created with unregistered dialect. If this is intended, please call allowUnregisteredDialects() on the MLIRContext, or use -allow-unregistered-dialect with the MLIR opt tool used
could not parse the input IR
```