### PR TITLE
remove bindings and skip tests when GC_ENABLE_DNNL=OFF

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -56,23 +56,25 @@ declare_mlir_python_sources(GcPythonSources.Common
 # Dialect bindings
 ################################################################################
 
-declare_mlir_dialect_python_bindings(
+if(GC_ENABLE_DNNL)
+  declare_mlir_dialect_python_bindings(
     ADD_TO_PARENT GcPythonSources
     ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gc_mlir"
     TD_FILE dialects/OneDNNGraphOps.td
     SOURCES 
       dialects/onednn_graph.py
     DIALECT_NAME onednn_graph
-    )
+  )
+endif()
 
-    declare_mlir_dialect_python_bindings(
-      ADD_TO_PARENT GcPythonSources
-      ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gc_mlir"
-      TD_FILE dialects/CPURuntimeOps.td
-      SOURCES 
-        dialects/cpuruntime.py
-      DIALECT_NAME cpuruntime
-      )
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT GcPythonSources
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gc_mlir"
+  TD_FILE dialects/CPURuntimeOps.td
+  SOURCES 
+    dialects/cpuruntime.py
+  DIALECT_NAME cpuruntime
+)
 
 declare_mlir_python_extension(GcPythonSources.Extension
   MODULE_NAME _gc_mlir

--- a/python/MainModule.cpp
+++ b/python/MainModule.cpp
@@ -29,7 +29,7 @@ PYBIND11_MODULE(_gc_mlir, m) {
   //===----------------------------------------------------------------------===//
   // OneDNNGraph
   //===----------------------------------------------------------------------===//
-
+#ifdef GC_HAS_ONEDNN_DIALECT
   auto onednn_graphM = m.def_submodule("onednn_graph");
   onednn_graphM.def(
       "register_dialect",
@@ -41,6 +41,7 @@ PYBIND11_MODULE(_gc_mlir, m) {
         }
       },
       py::arg("context") = py::none(), py::arg("load") = true);
+#endif
 
   //===----------------------------------------------------------------------===//
   // CPURuntime

--- a/python/gc_mlir/_mlir_libs/_site_initialize_0.py
+++ b/python/gc_mlir/_mlir_libs/_site_initialize_0.py
@@ -8,8 +8,16 @@
 
 
 def context_init_hook(context):
-    from ._gc_mlir.onednn_graph import register_dialect as register_onednn_graph_dialect
+
     from ._gc_mlir.cpuruntime import register_dialect as register_cpuruntime_dialect
-    
-    register_onednn_graph_dialect(context)
+
     register_cpuruntime_dialect(context)
+    
+    try:
+        from ._gc_mlir.onednn_graph import (
+            register_dialect as register_onednn_graph_dialect,
+        )
+
+        register_onednn_graph_dialect(context)
+    except ModuleNotFoundError:
+        print("onednn_graph dialect not found")

--- a/test/mlir/test/gc/Dialect/OneDNNGraph/lit.local.cfg
+++ b/test/mlir/test/gc/Dialect/OneDNNGraph/lit.local.cfg
@@ -1,0 +1,2 @@
+if not config.gc_use_dnnl:
+    config.unsupported = True

--- a/test/mlir/test/gc/python/dialects/lit.local.cfg
+++ b/test/mlir/test/gc/python/dialects/lit.local.cfg
@@ -1,0 +1,2 @@
+if not config.gc_use_dnnl:
+    config.excludes.add("onednn_graph.py")

--- a/test/mlir/test/gc/python/lit.local.cfg
+++ b/test/mlir/test/gc/python/lit.local.cfg
@@ -1,4 +1,7 @@
 config.suffixes.add(".py")
 
+if not config.gc_use_dnnl:
+    config.excludes.add("smoketest.py")
+
 if not config.enable_bindings_python:
     config.unsupported = True

--- a/test/mlir/test/lit.site.cfg.py.in
+++ b/test/mlir/test/lit.site.cfg.py.in
@@ -43,6 +43,7 @@ config.mlir_runner_utils = os.path.normpath(os.path.join(config.mlir_runner_util
 config.mlir_c_runner_utils = os.path.normpath(os.path.join(config.mlir_runner_utils_dir, config.shlib_prefix + "mlir_c_runner_utils" + config.llvm_shlib_ext))
 
 config.opencl_runtime = os.path.normpath(os.path.join(config.gc_lib_dir, config.shlib_prefix + "GcOpenclRuntime" + config.llvm_shlib_ext))
+config.gc_use_dnnl = "@GC_ENABLE_DNNL@"  in ["ON", "1"]
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
When `GC_ENABLE_DNNL=OFF`,  we still need 
* remove bindings of onednn_graph dialect
* skip test cases using onednn_graph dialect

track: https://github.com/intel/graph-compiler/issues/212