### PR TITLE
only emit target description warning in verify phase and correct the target op

### DIFF
--- a/include/gc/Analysis/TargetDescriptionAnalysis.h
+++ b/include/gc/Analysis/TargetDescriptionAnalysis.h
@@ -55,11 +55,15 @@ public:
   // the map from device type to device string
   static llvm::DenseMap<DeviceType, std::string> DeviceKeyMap;
 
+  // set the emit warning flag
+  void setEmitWarning(bool emit) { emitWarning = emit; }
+
 private:
   MLIRContext *ctx;
   DeviceType device;
   DataLayout layout;
   Location loc;
+  bool emitWarning = false;
 };
 
 class CPUTargetDescriptionAnalysis : public TargetDescriptionAnalysisBase {

--- a/lib/gc/Analysis/TargetDescriptionAnalysis.cpp
+++ b/lib/gc/Analysis/TargetDescriptionAnalysis.cpp
@@ -25,7 +25,9 @@ template <typename T>
 void TargetDescriptionAnalysisBase::emitNotFoundWarning(Location loc,
                                                         StringRef key,
                                                         T value) {
-  mlir::emitWarning(loc) << key << " not found, using default value " << value;
+  if (emitWarning)
+    mlir::emitWarning(loc) << key << " not found, using default value "
+                           << value;
 }
 
 static bool isIntegerNumber(const std::string &token) {

--- a/lib/gc/Transforms/Pipeline.cpp
+++ b/lib/gc/Transforms/Pipeline.cpp
@@ -134,7 +134,7 @@ void populateLLVMPasses(mlir::OpPassManager &pm) {
 
 void populateCPUPipeline(mlir::OpPassManager &pm) {
   // verify the target description attribute
-  pm.addNestedPass<func::FuncOp>(createVerifyTargetDescription());
+  pm.addPass(createVerifyTargetDescription());
   // front-end, oneDNN graph dialect
   populateFrontendPasses(pm);
   // middle-end, LinalgX/Linalg/tensor dialects

--- a/lib/gc/Transforms/VerifyTargetDescription.cpp
+++ b/lib/gc/Transforms/VerifyTargetDescription.cpp
@@ -24,6 +24,7 @@ namespace {
 static LogicalResult verifyCPUTargetDescription(RewriterBase &rewriter,
                                                 Operation *op) {
   CPUTargetDescriptionAnalysis cpuTargetDesc(op);
+  cpuTargetDesc.setEmitWarning(true);
   Location loc = op->getLoc();
 
   // Check if the num_threads is existed and greater than 0


### PR DESCRIPTION
* Avoid too many noisy warnings and only print warnings in the verification phase.
* Correct the pass target operation