### PR TITLE
[Transform][Fusion] Support fusion for K-tiling deep matmul

### DIFF
--- a/include/gc/Transforms/Passes.td
+++ b/include/gc/Transforms/Passes.td
@@ -59,25 +59,18 @@ def IterativeTilingAndFusion : Pass<"iterative-tiling-and-fusion",
       3. Multi-consumer and multi-producer support.
       4. Multiple level of nest loops and candidates.
       5. Flexible option to control the boundary of iterative process.
-      6. Cost-model to determine whether to fuse or not.
-
-    It intends to control the granularity of fusion by `fusion-level`, E.g.
-    * `0`: disable any fusion.
-    * `1`:[Default] enable both producer and consumer fusion, covering any tilable operation including tensor.pack/tensor.fill/linalg.reduce etc but excluding branches forked by multiple uses.
-    * `2`: `LEVEL 1` + extend to any topology including branches.
+      6. Default tiling when no op is tiled before fusion.
+      7. Cost-model to determine whether to fuse or not.
   }];
   let dependentDialects = ["func::FuncDialect", "linalg::LinalgDialect", "scf::SCFDialect",
                            "tensor::TensorDialect"];
 
   let options = [
-    Option<"fusionLevel", "fusion-level", "int64_t",
-           /*default=*/"1",
-           "Control the granularity of fusion.">,
     Option<"useCostModel", "use-cost-model", "bool",
            /*default=*/"false",
            "Decide if enable cost model to control iterative fusion.">,
     ListOption<"defaultTileSize", "default-tile-size", "std::string",
-           "Set default TileSize for the certain type of op, saying matmul:{32,32}">,
+           "Set default TileSize for the certain type of op, saying `matmul:{32,32}`">,
   ];
 }
 

--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -655,7 +655,9 @@ void iterativeTilingAndFusionUntilExhaustion(
         return WalkResult::skip();
       if (isa<TilingInterface>(op)) {
         auto parentLoop = op->getParentOfType<LoopLikeOpInterface>();
-        if (!parentLoop.getOperation())
+        auto parentGeneric = op->getParentOfType<linalg::GenericOp>();
+        if (!llvm::detail::isPresent(parentLoop) &&
+            !llvm::detail::isPresent(parentGeneric))
           unTiledOps.insert(op);
       }
       return WalkResult::advance();

--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -630,11 +630,11 @@ defaultTilingOfType(RewriterBase &rewriter, Operation *op,
   // d. Use builtin tiling interface
   FailureOr<scf::SCFTilingResult> tilingResult =
       scf::tileUsingSCF(rewriter, tilingInterfaceOp, options);
-  if (succeeded(tilingResult)) {
-    rewriter.replaceOp(op, tilingResult->replacements);
-    return tilingResult;
-  }
-  return failure();
+
+  if (failed(tilingResult))
+    return failure();
+
+  return tilingResult;
 }
 
 using DefaultTilingFn = std::function<FailureOr<scf::SCFTilingResult>(
@@ -701,6 +701,7 @@ void iterativeTilingAndFusionUntilExhaustion(
               tilingFn(rewriter, op, tsMap);
           if (succeeded(tilingResult)) {
             tiledOps.insert(tilingResult->tiledOps[0]);
+            rewriter.replaceOp(op, tilingResult->replacements);
             break;
           }
         }

--- a/lib/gc/Transforms/TilingUsingInterfaceX.cpp
+++ b/lib/gc/Transforms/TilingUsingInterfaceX.cpp
@@ -751,7 +751,10 @@ tileAndFuseConsumerOfSliceImpl(RewriterBase &rewriter,
   OpBuilder::InsertionGuard g(rewriter);
 
   // 2.b Check consumer is not using scf loop's output as init.
-  auto dstOp = cast<DestinationStyleOpInterface>(consumerOp);
+  auto dstOp = dyn_cast<DestinationStyleOpInterface>(consumerOp);
+  if (!dstOp)
+    return rewriter.notifyMatchFailure(consumerOp,
+                                       "consumer op is not DPS operation");
   SmallVector<Value> dpsInits =
       llvm::map_to_vector(dstOp.getDpsInits(), [](Value v) { return v; });
   if (llvm::is_contained(dpsInits, oldTopLevelLoop->getResult(resultNumber))) {

--- a/lib/gc/Transforms/TilingUsingInterfaceX.cpp
+++ b/lib/gc/Transforms/TilingUsingInterfaceX.cpp
@@ -545,6 +545,8 @@ getUntiledConsumerFromSlice(tensor::ParallelInsertSliceOp candidateSliceOp) {
 /// %1 = firstUserOfLoop(%0)
 /// ```
 ///
+/// Besides, `consumerOp` should not be the user of `firstUserOfLoop`.
+///
 /// @param loopOp: loop operation
 /// @param consumerOp: consumer operation
 /// @param insertPointBefore: which operation we clone the looOp right before
@@ -556,51 +558,60 @@ static LogicalResult checkAssumptionForLoop(Operation *loopOp,
   if (loopOp->getBlock() != parentBlock)
     return failure();
 
-  Operation *firstUserOfLoop = consumerOp, *lastDefOfConsumer = loopOp;
-  // Find the first user of loopOp
-  for (Operation *userOp : loopOp->getUsers()) {
-    if (userOp == consumerOp)
-      continue;
-    // `ParallelInsertSlice` located inside `InParallelOp` has no same parent
-    // block with any other types of operation. Thus, just redirecting to its
-    // parent `InParallelOp`.
-    if (isa<tensor::ParallelInsertSliceOp>(userOp))
-      userOp = userOp->getParentOfType<scf::InParallelOp>();
+  *insertPointBefore = nullptr;
+  do {
+    Operation *firstUserOfLoop = consumerOp, *lastDefOfConsumer = loopOp;
+    // Find the first user of loopOp
+    for (Operation *userOp : loopOp->getUsers()) {
+      if (userOp == consumerOp)
+        continue;
+      // `ParallelInsertSlice` located inside `InParallelOp` has no same parent
+      // block with any other types of operation. Thus, just redirecting to its
+      // parent `InParallelOp`.
+      if (isa<tensor::ParallelInsertSliceOp>(userOp))
+        userOp = userOp->getParentOfType<scf::InParallelOp>();
 
-    if (parentBlock != userOp->getBlock())
-      return failure();
+      if (parentBlock != userOp->getBlock())
+        return failure();
 
-    if (userOp->isBeforeInBlock(firstUserOfLoop))
-      firstUserOfLoop = userOp;
-  }
-  // Find the last define of consumer
-  for (Value operand : consumerOp->getOperands()) {
-    // If the operand is `BlockArgument`, auto skip.
-    if (isa<BlockArgument>(operand))
-      continue;
-    auto defineOp = operand.getDefiningOp();
-    if (defineOp == loopOp)
-      continue;
-    if (!defineOp || parentBlock != defineOp->getBlock())
-      return failure();
-    if (lastDefOfConsumer->isBeforeInBlock(defineOp))
-      lastDefOfConsumer = defineOp;
-  }
-  if (firstUserOfLoop->isBeforeInBlock(lastDefOfConsumer)) {
-    // Try to move if possible
-    if (llvm::all_of(firstUserOfLoop->getUsers(),
-                     [&lastDefOfConsumer, &parentBlock](Operation *userOp) {
-                       return userOp->getBlock() == parentBlock &&
-                              lastDefOfConsumer->isBeforeInBlock(userOp);
-                     })) {
-      // Safely moving
-      firstUserOfLoop->moveAfter(lastDefOfConsumer);
-    } else {
-      return failure();
+      if (userOp->isBeforeInBlock(firstUserOfLoop))
+        firstUserOfLoop = userOp;
     }
-  }
-  // Set InsertPoint
-  *insertPointBefore = firstUserOfLoop;
+
+    // Find the last define of consumer
+    for (Value operand : consumerOp->getOperands()) {
+      // If the operand is `BlockArgument`, auto skip.
+      if (isa<BlockArgument>(operand))
+        continue;
+      auto defineOp = operand.getDefiningOp();
+      if (defineOp == loopOp)
+        continue;
+      if (!defineOp || parentBlock != defineOp->getBlock())
+        return failure();
+      if (lastDefOfConsumer->isBeforeInBlock(defineOp))
+        lastDefOfConsumer = defineOp;
+    }
+    if (firstUserOfLoop->isBeforeInBlock(lastDefOfConsumer)) {
+      // Try to move if possible
+      if (llvm::all_of(firstUserOfLoop->getUsers(),
+                       [&lastDefOfConsumer, &parentBlock](Operation *userOp) {
+                         return userOp->getBlock() == parentBlock &&
+                                lastDefOfConsumer->isBeforeInBlock(userOp);
+                       })) {
+        // Safely moving
+        firstUserOfLoop->moveAfter(lastDefOfConsumer);
+      } else {
+        return failure();
+      }
+    } else {
+      // Check consumerOp is not the user of firstUserOfLoop
+      if (firstUserOfLoop == lastDefOfConsumer)
+        return failure();
+      // Set InsertPoint
+      *insertPointBefore = firstUserOfLoop;
+    }
+  } while (!(*insertPointBefore));
+
   return success();
 }
 

--- a/test/mlir/test/gc/Transforms/iterative-tiling-and-fusion.mlir
+++ b/test/mlir/test/gc/Transforms/iterative-tiling-and-fusion.mlir
@@ -219,3 +219,96 @@ module {
     return %1 : tensor<128x256xf32>
   }
 }
+
+// -----
+
+module {
+  /// CHECK-LABEL: @fuse_llama2_matmul_add
+  func.func @fuse_llama2_matmul_add(%arg0: tensor<32x4096xbf16>, %arg1: tensor<4096x4096xbf16>, %arg2: tensor<32x4096xbf16>) -> tensor<32x4096xbf16> {
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %c16 = arith.constant 16 : index
+    %c128 = arith.constant 128 : index
+    %c0 = arith.constant 0 : index
+    %cst = arith.constant 0.000000e+00 : bf16
+    %0 = tensor.empty() : tensor<1x128x32x32xbf16>
+    %pack = tensor.pack %arg0 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %0 : tensor<32x4096xbf16> -> tensor<1x128x32x32xbf16>
+    %1 = tensor.empty() : tensor<128x128x32x32xbf16>
+    %pack_0 = tensor.pack %arg1 outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %1 : tensor<4096x4096xbf16> -> tensor<128x128x32x32xbf16>
+    %2 = tensor.empty() : tensor<1x128x32x32xbf16>
+    %3 = tensor.empty() : tensor<128x128x16x32x2xbf16>
+    %pack_1 = tensor.pack %pack_0 inner_dims_pos = [2] inner_tiles = [2] into %3 : tensor<128x128x32x32xbf16> -> tensor<128x128x16x32x2xbf16>
+    /// CHECK:   %[[FINAL_RESULT:.*]]:3 = scf.for
+    %4 = scf.for %arg3 = %c0 to %c128 step %c16 iter_args(%arg4 = %2) -> (tensor<1x128x32x32xbf16>) {
+      %extracted_slice = tensor.extract_slice %arg4[0, %arg3, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : tensor<1x128x32x32xbf16> to tensor<1x16x32x32xbf16>
+      %9 = tensor.empty() : tensor<1x16x32x32xf32>
+      /// CHECK: scf.for
+      /// CHECK: scf.for
+      %10:2 = scf.for %arg5 = %c0 to %c128 step %c32 iter_args(%arg6 = %9, %arg7 = %extracted_slice) -> (tensor<1x16x32x32xf32>, tensor<1x16x32x32xbf16>) {
+        %11:2 = scf.for %arg8 = %c0 to %c16 step %c1 iter_args(%arg9 = %arg6, %arg10 = %arg7) -> (tensor<1x16x32x32xf32>, tensor<1x16x32x32xbf16>) {
+          %extracted_slice_3 = tensor.extract_slice %pack[0, %arg5, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : tensor<1x128x32x32xbf16> to tensor<1x32x32x32xbf16>
+          %12 = affine.apply affine_map<()[s0, s1] -> (s0 + s1)>()[%arg8, %arg3]
+          /// CHECK: %[[PACK_OUT_1:.*]] = tensor.pack
+          /// CHECK: %[[PACK_OUT_2:.*]] = tensor.pack
+          /// CHECK: %[[PACK_OUT_3:.*]] = tensor.pack %[[PACK_OUT_2]]
+          %extracted_slice_4 = tensor.extract_slice %pack_1[%12, %arg5, 0, 0, 0] [1, 32, 16, 32, 2] [1, 1, 1, 1, 1] : tensor<128x128x16x32x2xbf16> to tensor<1x32x16x32x2xbf16>
+          %extracted_slice_5 = tensor.extract_slice %arg9[0, %arg8, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<1x16x32x32xf32> to tensor<1x1x32x32xf32>
+          %extracted_slice_6 = tensor.extract_slice %arg10[0, %arg8, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<1x16x32x32xbf16> to tensor<1x1x32x32xbf16>
+          /// CHECK: %[[COLLAPSE_OUT_1:.*]] = tensor.collapse_shape %[[PACK_OUT_1]]
+          /// CHECK: %[[COLLAPSE_OUT_2:.*]] = tensor.collapse_shape %[[PACK_OUT_3]]
+          %collapse_3 = tensor.collapse_shape %extracted_slice_3 [[0, 1], [2], [3]] : tensor<1x32x32x32xbf16> into tensor<32x32x32xbf16>
+          %collapse_4 = tensor.collapse_shape %extracted_slice_4 [[0, 1], [2], [3], [4]] : tensor<1x32x16x32x2xbf16> into tensor<32x16x32x2xbf16>
+          %collapse_5 = tensor.collapse_shape %extracted_slice_5 [[0, 1, 2], [3]] : tensor<1x1x32x32xf32> into tensor<32x32xf32>
+          %collapse_6 = tensor.collapse_shape %extracted_slice_6 [[0, 1, 2], [3]] : tensor<1x1x32x32xbf16> into tensor<32x32xbf16>
+          %13 = arith.cmpi eq, %arg5, %c0 : index
+          /// CHECK: %[[IF_RESULT_1:.*]] = scf.if
+          /// CHECK: linalgx.batch_reduce_matmul_vnni ins(%[[COLLAPSE_OUT_1]], %[[COLLAPSE_OUT_2]] :
+          /// CHECK: } else {
+          /// CHECK: linalgx.batch_reduce_matmul_vnni ins(%[[COLLAPSE_OUT_1]], %[[COLLAPSE_OUT_2]] :
+          /// CHECK: }
+          %14 = scf.if %13 -> (tensor<32x32xf32>) {
+            %18 = linalg.fill ins(%cst : bf16) outs(%collapse_5 : tensor<32x32xf32>) -> tensor<32x32xf32>
+            %19 = linalgx.batch_reduce_matmul_vnni ins(%collapse_3, %collapse_4 : tensor<32x32x32xbf16>, tensor<32x16x32x2xbf16>) outs(%18 : tensor<32x32xf32>) -> tensor<32x32xf32>
+            scf.yield %19 : tensor<32x32xf32>
+          } else {
+            %18 = linalgx.batch_reduce_matmul_vnni ins(%collapse_3, %collapse_4 : tensor<32x32x32xbf16>, tensor<32x16x32x2xbf16>) outs(%collapse_5 : tensor<32x32xf32>) -> tensor<32x32xf32>
+            scf.yield %18 : tensor<32x32xf32>
+          }
+          %15 = arith.addi %arg5, %c32 : index
+          %16 = arith.cmpi sge, %15, %c128 : index
+          /// CHECK: %[[IF_RESULT_2:.*]] = scf.if
+          %17 = scf.if %16 -> (tensor<32x32xbf16>) {
+            %18 = linalg.copy ins(%14 : tensor<32x32xf32>) outs(%collapse_6 : tensor<32x32xbf16>) -> tensor<32x32xbf16>
+            scf.yield %18 : tensor<32x32xbf16>
+          } else {
+            scf.yield %collapse_6 : tensor<32x32xbf16>
+          }
+          /// CHECK: %[[EXPAND_OUT_1:.*]] = tensor.expand_shape %[[IF_RESULT_1]]
+          /// CHECK: %[[EXPAND_OUT_2:.*]] = tensor.expand_shape %[[IF_RESULT_2]]
+          %expand_14 = tensor.expand_shape %14 [[0, 1, 2], [3]] output_shape [1, 1, 32, 32] : tensor<32x32xf32> into tensor<1x1x32x32xf32>
+          %expand_17 = tensor.expand_shape %17 [[0, 1, 2], [3]] output_shape [1, 1, 32, 32] : tensor<32x32xbf16> into tensor<1x1x32x32xbf16>
+          /// CHECK: %[[PACK_OUT_4:.*]] = tensor.pack
+          /// CHECK: %[[ADD_OUT:.*]] = linalg.add ins(%[[EXPAND_OUT_2]], %[[PACK_OUT_4]] :
+          /// CHECK: %[[UNPACK_OUT:.*]] = tensor.unpack %[[ADD_OUT]]
+          %inserted_slice_7 = tensor.insert_slice %expand_14 into %arg9[0, %arg8, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<1x1x32x32xf32> into tensor<1x16x32x32xf32>
+          %inserted_slice_8 = tensor.insert_slice %expand_17 into %arg10[0, %arg8, 0, 0] [1, 1, 32, 32] [1, 1, 1, 1] : tensor<1x1x32x32xbf16> into tensor<1x16x32x32xbf16>
+          /// CHECK: scf.yield {{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x16x32x32xf32>, tensor<1x16x32x32xbf16>, tensor<1x16x32x32xbf16>, tensor<32x512xbf16>
+          scf.yield %inserted_slice_7, %inserted_slice_8 : tensor<1x16x32x32xf32>, tensor<1x16x32x32xbf16>
+        }
+        /// CHECK: scf.yield {{.*}}, {{.*}}, {{.*}}, {{.*}} : tensor<1x16x32x32xf32>, tensor<1x16x32x32xbf16>, tensor<1x16x32x32xbf16>, tensor<32x512xbf16>
+        scf.yield %11#0, %11#1 : tensor<1x16x32x32xf32>, tensor<1x16x32x32xbf16>
+      }
+      /// CHECK: scf.yield {{.*}}, {{.*}}, {{.*}}: tensor<1x128x32x32xbf16>, tensor<1x128x32x32xbf16>, tensor<32x4096xbf16>
+      %inserted_slice = tensor.insert_slice %10#1 into %arg4[0, %arg3, 0, 0] [1, 16, 32, 32] [1, 1, 1, 1] : tensor<1x16x32x32xbf16> into tensor<1x128x32x32xbf16>
+      scf.yield %inserted_slice : tensor<1x128x32x32xbf16>
+    }
+    %5 = tensor.empty() : tensor<32x4096xbf16>
+    %6 = tensor.empty() : tensor<1x128x32x32xbf16>
+    %pack_2 = tensor.pack %arg2 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %6 : tensor<32x4096xbf16> -> tensor<1x128x32x32xbf16>
+    %7 = tensor.empty() : tensor<1x128x32x32xbf16>
+    %8 = linalg.add ins(%4, %pack_2 : tensor<1x128x32x32xbf16>, tensor<1x128x32x32xbf16>) outs(%7 : tensor<1x128x32x32xbf16>) -> tensor<1x128x32x32xbf16>
+    %unpack = tensor.unpack %8 outer_dims_perm = [0, 1] inner_dims_pos = [0, 1] inner_tiles = [32, 32] into %5 : tensor<1x128x32x32xbf16> -> tensor<32x4096xbf16>
+    /// CHECK: return %[[FINAL_RESULT]]#2
+    return %unpack : tensor<32x4096xbf16>
+  }
+}

--- a/test/mlir/test/gc/Transforms/iterative-tiling-and-fusion.mlir
+++ b/test/mlir/test/gc/Transforms/iterative-tiling-and-fusion.mlir
@@ -1,14 +1,6 @@
 // RUN: gc-opt --split-input-file -iterative-tiling-and-fusion %s --cse
 
-module attributes {
-  dlti.target_system_spec = #dlti.target_system_spec<
-    "CPU": #dlti.target_device_spec<
-      #dlti.dl_entry<"L1_cache_size_in_bytes", 49152 : i32>,
-      #dlti.dl_entry<"L2_cache_size_in_bytes", 2097152 : i32>,
-      #dlti.dl_entry<"L3_cache_size_in_bytes", 110100480 : i32>,
-      #dlti.dl_entry<"num_threads", 56 : i32>,
-      #dlti.dl_entry<"max_vector_width", 512 : i32>>
-  >} {
+module {
   /// CHECK-LABEL: @fuse_mlp
   func.func @fuse_mlp(%arg0: tensor<128x512xbf16>, %arg1: tensor<32x8x16x32xbf16>, %arg2: tensor<256xbf16>) -> tensor<128x256xbf16> {
     %c32 = arith.constant 32 : index
@@ -104,15 +96,7 @@ module attributes {
 // -----
 
 #map = affine_map<(d0) -> (d0 * 128)>
-module attributes {
-  dlti.target_system_spec = #dlti.target_system_spec<
-    "CPU": #dlti.target_device_spec<
-      #dlti.dl_entry<"L1_cache_size_in_bytes", 49152 : i32>,
-      #dlti.dl_entry<"L2_cache_size_in_bytes", 2097152 : i32>,
-      #dlti.dl_entry<"L3_cache_size_in_bytes", 110100480 : i32>,
-      #dlti.dl_entry<"num_threads", 56 : i32>,
-      #dlti.dl_entry<"max_vector_width", 512 : i32>>
-  >} {
+module {
   /// CHECK-LABEL: @fuse_multiple_consumer
   func.func @fuse_multiple_consumer(%arg0: tensor<256x512xf32>, %arg1: tensor<512x256xf32>, %arg2: tensor<256x256xf32>, %arg3: tensor<256x256xf32>) -> (tensor<256x256xf32>, tensor<256x256xf32>) {
     %c0 = arith.constant 0 : index
@@ -163,15 +147,7 @@ module attributes {
 // -----
 
 #map = affine_map<(d0) -> (d0 * 128)>
-module attributes {
-  dlti.target_system_spec = #dlti.target_system_spec<
-    "CPU": #dlti.target_device_spec<
-      #dlti.dl_entry<"L1_cache_size_in_bytes", 49152 : i32>,
-      #dlti.dl_entry<"L2_cache_size_in_bytes", 2097152 : i32>,
-      #dlti.dl_entry<"L3_cache_size_in_bytes", 110100480 : i32>,
-      #dlti.dl_entry<"num_threads", 56 : i32>,
-      #dlti.dl_entry<"max_vector_width", 512 : i32>>
-  >} {
+module {
   /// CHECK-LABEL: @fuse_reduce
   func.func @fuse_reduce(%arg0: tensor<256x512xf32>, %arg1: tensor<512x256xf32>, %arg2: tensor<256x256xf32>) -> tensor<256xf32> {
     %c0 = arith.constant 0 : index
@@ -223,15 +199,7 @@ module attributes {
 
 // -----
 
-module attributes {
-  dlti.target_system_spec = #dlti.target_system_spec<
-    "CPU": #dlti.target_device_spec<
-      #dlti.dl_entry<"L1_cache_size_in_bytes", 49152 : i32>,
-      #dlti.dl_entry<"L2_cache_size_in_bytes", 2097152 : i32>,
-      #dlti.dl_entry<"L3_cache_size_in_bytes", 110100480 : i32>,
-      #dlti.dl_entry<"num_threads", 56 : i32>,
-      #dlti.dl_entry<"max_vector_width", 512 : i32>>
-  >} {
+module {
   /// CHECK-LABEL: @fuse_with_default_tiling
   func.func @fuse_with_default_tiling(%arg0: tensor<128x256x256xf32>, %arg1: tensor<128x256x256xf32>) -> tensor<128x256xf32> {
     %dest0 = tensor.empty() : tensor<128x256x256xf32>


### PR DESCRIPTION
Fix issue found in llama2-MLP.

A kind reminder: Please DO NOT use rank-altering behavior of `*_slice`. 

```
%extracted_slice_3 = tensor.extract_slice %pack[0, %arg5, 0, 0] [1, 32, 32, 32] [1, 1, 1, 1] : tensor<1x128x32x32xbf16> to tensor<32x32x32xbf16>
%19 = linalgx.batch_reduce_matmul_vnni ins(%extracted_slice_3, %extracted_slice_4 : tensor<32x32x32xbf16>, tensor<32x16x32x2xbf16>) outs(%18 : tensor<32x32xf32>) -> tensor<32x32xf32>
```

Although it is valid and convenient to implicitly reduce rank from `[1, 32, 32, 32]` to `[32, 32, 32]`, fused `packOp` will never yield `[32, 32, 32]`, which will lead to unexpected conflict finally.

Instead, Please explicitly use `tensor.collapse_shape` and `tensor.expand_shape` to alter rank of `*_slice`.

