### PR TITLE
Enable affine op lowering

### DIFF
--- a/lib/gc/Transforms/Pipeline.cpp
+++ b/lib/gc/Transforms/Pipeline.cpp
@@ -111,6 +111,7 @@ void populateCPURuntimePasses(mlir::OpPassManager &pm) {
 }
 
 void populateLoweringToLLVMPasses(mlir::OpPassManager &pm) {
+  pm.addPass(createLowerAffinePass());
   pm.addPass(createFinalizeMemRefToLLVMConversionPass());
   pm.addPass(createConvertSCFToCFPass());
   pm.addPass(cpuruntime::createCPURuntimeToLLVM());


### PR DESCRIPTION
Tracking https://github.com/intel/graph-compiler/issues/218
The root issue is the affine op(`affine.apply`) hasn't been lowered to the llvm dialect so that the `unrealized_conversion_cast` cannot be eliminated by the pass `--reconcile-unrealized-casts`