### PR TITLE
[Transform][Fusion] support fusion for residual pattern

### DIFF
--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -228,19 +228,37 @@ NonContractionOpFilter(RewriterBase &rewriter,
   return failure(isa<mlir::linalg::ContractionOpInterface>(defOrUse.ownerOp));
 }
 
+/// If fusing multiple consumers is allowed, there may exist following cases:
+///
+/// ```
+/// %1:2 = scf.for() {
+///     %2 = tiled_op1
+///     %3 = tiled_op2
+///     %4 = insert_slice %2
+///     %5 = insert_slice %3
+///     yield %4, %5
+/// }
+/// op3 ins(%1#1, %1#2)
+/// ```
+///
+/// Where we need to ensure their `tileOffset` and `tileSize` are matched well.
 static LogicalResult
-SingleCandidateInBlockFilter(RewriterBase &rewriter,
-                             OffsetSizeAndStrideOpInterface candidate,
-                             CandidateDefOrUse defOrUse) {
+SingleCandidateElseTileMatchedFilter(RewriterBase &rewriter,
+                                     OffsetSizeAndStrideOpInterface candidate,
+                                     CandidateDefOrUse defOrUse) {
   Block *parent = candidate->getBlock();
+  // No matter candidates correspond to which operand or result of operation,
+  // align all of them to `tileOffset` and `tileSize` on iteration domain for
+  // easy comparision.
+  SmallVector<OpFoldResult> iterDomainOffsets, iterDomainSizes;
 
-  // a. traverse all ops contained in parent Block.
+  // a. traverse all ops contained in the same parent Block.
   for (auto &opInBlock : parent->getOperations()) {
     // b. skip candidate slice
     if (&opInBlock == candidate.getOperation())
       continue;
     // c. check if all the other sliceOp not defined or used by the same owner
-    // with candidate slice.
+    // with candidate slice. Otherwise, they must be pretty matched.
     if (auto otherCandidate =
             dyn_cast<OffsetSizeAndStrideOpInterface>(&opInBlock)) {
       if (defOrUse.isDef()) {
@@ -256,11 +274,48 @@ SingleCandidateInBlockFilter(RewriterBase &rewriter,
         FailureOr<SmallVector<OpOperand *>> realConsumers =
             scfX::getRealConsumersFromInsertSliceOp(otherCandidate,
                                                     forwardSlice);
+        // Record operand pointer of same owner.
+        OpOperand *operandOfSameOwner = nullptr;
         if (succeeded(realConsumers) &&
-            llvm::any_of(*realConsumers, [&defOrUse](OpOperand *use) {
-              return use->getOwner() == defOrUse.ownerOp;
-            }))
-          return failure();
+            llvm::any_of(*realConsumers,
+                         [&defOrUse, &operandOfSameOwner](OpOperand *use) {
+                           if (use->getOwner() != defOrUse.ownerOp)
+                             return false;
+                           operandOfSameOwner = use;
+                           return true;
+                         })) {
+          assert(operandOfSameOwner);
+          // In avoid of repeated computation.
+          if (iterDomainOffsets.empty() || iterDomainSizes.empty()) {
+            // Compute `tileOffset` and `tileSize` on iteration domain based on
+            // given candidate.
+            rewriter.setInsertionPointAfter(candidate);
+            if (failed(cast<TilingInterface>(defOrUse.ownerOp)
+                           .getIterationDomainTileFromOperandTile(
+                               rewriter, defOrUse.operand->getOperandNumber(),
+                               candidate.getMixedOffsets(),
+                               candidate.getMixedSizes(), iterDomainOffsets,
+                               iterDomainSizes)))
+              return failure();
+          }
+          // Compute `tileOffset` and `tileSize` on iteration domain based on
+          // other candidate.
+          SmallVector<OpFoldResult> otherIterDomainOffsets,
+              otherIterDomainSizes;
+          rewriter.setInsertionPointAfter(otherCandidate);
+          if (failed(cast<TilingInterface>(defOrUse.ownerOp)
+                         .getIterationDomainTileFromOperandTile(
+                             rewriter, operandOfSameOwner->getOperandNumber(),
+                             otherCandidate.getMixedOffsets(),
+                             otherCandidate.getMixedSizes(),
+                             otherIterDomainOffsets, otherIterDomainSizes)))
+            return failure();
+
+          // d. Check if all inferred `tileOffset` and `tileSize` of iteration
+          // domain from different operands are matched.
+          return success(iterDomainOffsets == otherIterDomainOffsets &&
+                         iterDomainSizes == otherIterDomainSizes);
+        }
       }
     }
   }
@@ -301,7 +356,7 @@ struct CandidateSliceFilterPipeLine
   SmallVector<CandidateSliceFilter> getDefaultPipeLine() {
     return SmallVector<CandidateSliceFilter>{
         unTiledOpFilter, NonContractionOpFilter, noTilingOnReductionFilter,
-        exactTilingOnPackUnPackFilter, SingleCandidateInBlockFilter};
+        exactTilingOnPackUnPackFilter, SingleCandidateElseTileMatchedFilter};
   }
 
   LogicalResult filter(RewriterBase &rewriter,

--- a/lib/gc/Transforms/TilingUsingInterfaceX.cpp
+++ b/lib/gc/Transforms/TilingUsingInterfaceX.cpp
@@ -681,6 +681,91 @@ fixTerminatorSCFInParallel(RewriterBase &rewriter, scf::ForallOp newForallOp,
   }
 }
 
+/// To solve following residual topology:
+///
+///   op1
+///   /  \
+///   |  op2
+///   |   /
+///   op3
+///
+/// Where the possible IR may appears like below before fusing `op3`:
+///
+/// ```
+/// %1:2 = scf.for() {
+///     %2 = tiled_op1
+///     %3 = tiled_op2
+///     %4 = insert_slice %2
+///     %5 = insert_slice %3
+///     yield %4, %5
+/// }
+/// op3 ins(%1#1, %1#2)
+/// ```
+///
+/// Although current fuse consumer only accepts single one candidate slice such
+/// as `%4`, in fact, `%5` is another regarding slice which produces the operand
+/// of untiled `op3`. Thus, is is necessary to find all of them and ensure that
+/// they are pretty matched.
+///
+/// @param loopOp: loop operation
+/// @param consumerOp: consumer operation
+/// @param curOperandNumber: operand number of current candidate slice
+/// @param otherOperandSliceMap: operand number to other slice mapping
+/// @return LogicalResult: Return `success` only if all operand slice are found.
+static LogicalResult findOtherOperandSlice(
+    Operation *loopOp, Operation *consumerOp, unsigned curOperandNumber,
+    DenseMap<unsigned, OffsetSizeAndStrideOpInterface> &otherOperandSliceMap) {
+  otherOperandSliceMap.clear();
+  SmallVector<OpOperand *> otherUseOfLoop;
+  for (auto &&[en, v] : llvm::enumerate(consumerOp->getOpOperands())) {
+    if (en == curOperandNumber)
+      continue;
+    if (v.get().getDefiningOp() == loopOp) {
+      otherUseOfLoop.push_back(&v);
+    }
+  }
+  if (otherUseOfLoop.empty())
+    return success();
+  if (auto forallOp = dyn_cast<scf::ForallOp>(loopOp)) {
+    for (auto &use : otherUseOfLoop) {
+      tensor::ParallelInsertSliceOp sliceOp;
+      for (auto &useOfResult :
+           forallOp
+               .getRegionIterArgs()[dyn_cast<OpResult>(use->get())
+                                        .getResultNumber()]
+               .getUses()) {
+        if (isa<tensor::ParallelInsertSliceOp>(useOfResult.getOwner())) {
+          if (llvm::detail::isPresent(sliceOp))
+            return failure();
+          sliceOp = cast<tensor::ParallelInsertSliceOp>(useOfResult.getOwner());
+          otherOperandSliceMap[use->getOperandNumber()] =
+              cast<OffsetSizeAndStrideOpInterface>(sliceOp.getOperation());
+        }
+      }
+      if (!llvm::detail::isPresent(sliceOp))
+        return failure();
+    }
+  } else if (auto forOp = dyn_cast<scf::ForOp>(loopOp)) {
+    for (auto &use : otherUseOfLoop) {
+      OpOperand *yieldValue = forOp.getTiedLoopYieldedValue(
+          forOp.getTiedLoopRegionIterArg(dyn_cast<OpResult>(use->get())));
+      Operation *yieldValueProducer = yieldValue->get().getDefiningOp();
+      while (!isa<tensor::InsertSliceOp>(yieldValueProducer)) {
+        if (!isa<scf::ForOp>(yieldValueProducer))
+          return failure();
+        scf::ForOp innerForOp = cast<scf::ForOp>(yieldValueProducer);
+        yieldValue = innerForOp.getTiedLoopYieldedValue(
+            innerForOp.getTiedLoopRegionIterArg(
+                dyn_cast<OpResult>(yieldValue->get())));
+        yieldValueProducer = yieldValue->get().getDefiningOp();
+      }
+      otherOperandSliceMap[use->getOperandNumber()] =
+          cast<OffsetSizeAndStrideOpInterface>(yieldValueProducer);
+    }
+  }
+  return success();
+}
+
 /// Implementation of fusing consumer of a single slice by computing the
 /// slice of the consumer in-place for scf loop.
 /// As for `insertSlice`, it also supports nest outer loop structure without
@@ -759,9 +844,19 @@ tileAndFuseConsumerOfSliceImpl(RewriterBase &rewriter,
                          "and no suitable insertPoint is found");
   }
 
+  // 2.b Check containing loop op has no more than one uses in consumerOp,
+  // otherwise, it must find all other slices.
+  DenseMap<unsigned int, OffsetSizeAndStrideOpInterface> otherOperandSliceMap;
+  if (failed(findOtherOperandSlice(oldTopLevelLoop, consumerOp, operandNumber,
+                                   otherOperandSliceMap))) {
+    return rewriter.notifyMatchFailure(
+        oldTopLevelLoop, "containing loop op has more than one uses in "
+                         "consumerOp, but could not find all other slices");
+  }
+
   OpBuilder::InsertionGuard g(rewriter);
 
-  // 2.b Check consumer is not using scf loop's output as init.
+  // 2.c Check consumer is not using scf loop's output as init.
   auto dstOp = dyn_cast<DestinationStyleOpInterface>(consumerOp);
   if (!dstOp)
     return rewriter.notifyMatchFailure(consumerOp,
@@ -895,13 +990,33 @@ tileAndFuseConsumerOfSliceImpl(RewriterBase &rewriter,
         candidateSliceOp, "containingOp's result yield with stride");
   }
 
-  // 10. Try to get iter domain position from input position.
+  // 10.a. Try to get iter domain position from input position.
   SmallVector<OpFoldResult> iterDomainOffsets, iterDomainSizes;
   if (failed(clonedConsumerOp.getIterationDomainTileFromOperandTile(
           rewriter, operandNumber, offsets, sizes, iterDomainOffsets,
           iterDomainSizes))) {
     return rewriter.notifyMatchFailure(
         clonedConsumerOp, "can't get iter domain position from input position");
+  }
+
+  if (!otherOperandSliceMap.empty()) {
+    for (auto &&[otherOperandNumber, otherSlice] : otherOperandSliceMap) {
+      // 10.b. Check if all inferred `tileOffset` and `tileSize` of iteration
+      // domain based on different operands are matched.
+      SmallVector<OpFoldResult> otherIterDomainOffsets, otherIterDomainSizes;
+      if (failed(clonedConsumerOp.getIterationDomainTileFromOperandTile(
+              rewriter, otherOperandNumber, otherSlice.getMixedOffsets(),
+              otherSlice.getMixedSizes(), otherIterDomainOffsets,
+              otherIterDomainSizes)) ||
+          (iterDomainOffsets != otherIterDomainOffsets ||
+           iterDomainSizes != otherIterDomainSizes)) {
+        return rewriter.notifyMatchFailure(
+            otherSlice, "does not match with candidate slice");
+      }
+      rewriter.replaceAllUsesWith(
+          tileAndFuseResult->tiledOps[0]->getOperand(otherOperandNumber),
+          otherSlice->getOperand(0));
+    }
   }
 
   // 11. Try to fetch the offset and size for all results of the cloned

--- a/lib/gc/Transforms/TilingUsingInterfaceX.cpp
+++ b/lib/gc/Transforms/TilingUsingInterfaceX.cpp
@@ -720,9 +720,8 @@ static LogicalResult findOtherOperandSlice(
   for (auto &&[en, v] : llvm::enumerate(consumerOp->getOpOperands())) {
     if (en == curOperandNumber)
       continue;
-    if (v.get().getDefiningOp() == loopOp) {
+    if (v.get().getDefiningOp() == loopOp)
       otherUseOfLoop.push_back(&v);
-    }
   }
   if (otherUseOfLoop.empty())
     return success();


### PR DESCRIPTION
Compared with upstream MLIR, although we have enabled multiple consumers fusion, it furthermore need to solve following residual topology: (It seems also found in llama MLP and MHA)

```
op1
/  \
|  op2
|   /
op3
```

where the possible IR may appears like below before fusing `op3`:

```
%1:2 = scf.for() {
%2 = tiled_op1
%3 = tiled_op2
%4 = insert_slice %2
%5 = insert_slice %3
yield %4, %5
}
op3 ins(%1#1, %1#2)
```

Current fuse consumer only accepts single one candidate slice, saying `%4`, However, in fact, `%5` is another slice regarding to operand of untiled `op3`. Thus, is is necessary to find all of the them and make sure that they are pretty matched.

BTW, this is also an interesting topic concerned by community in our upstream [RFC](https://discourse.llvm.org/t/rfc-introduce-new-pass-transform-fusion-by-diffusion/79603/4?u=yunfly).