### PR TITLE
[Transform][Fusion] fix pack/unpack filter

### DIFF
--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -156,7 +156,8 @@ exactTilingOnPackUnPackFilter(RewriterBase &rewriter,
     return success();
 
   SmallVector<OpFoldResult> tileSizes = candidate.getMixedSizes();
-  // collect target TileSizes and InnerTileSize to compare
+  // collect target tileSizesOnInnerDims to compare with `inner_tiles` of
+  // `PackOp` or `unPackOp`.
   SmallVector<OpFoldResult> tileSizesOnInnerDims, innerTiles;
   if (auto packOp = dyn_cast<tensor::PackOp>(defOrUse.ownerOp)) {
     innerTiles = packOp.getMixedTiles();
@@ -186,7 +187,7 @@ exactTilingOnPackUnPackFilter(RewriterBase &rewriter,
     }
   }
 
-  // check tileSizes is full on or multiple of `inner_tile_size`
+  // check tileSizes is full on or multiple of `inner_tiles`
   for (auto [tile, innerTile] :
        llvm::zip_equal(tileSizesOnInnerDims, innerTiles)) {
     if (isEqualConstantIntOrValue(tile, innerTile))

--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -768,7 +768,8 @@ void iterativeTilingAndFusionUntilExhaustion(
           defaultTilingOfType<mlir::linalg::ContractionOpInterface>,
           defaultTilingOfType<mlir::linalg::ReduceOp>,
           defaultTilingOfType<mlir::linalg::LinalgOp>,
-          defaultTilingOfType<tensor::PackOp, tensor::UnPackOp, tensor::PadOp>};
+          defaultTilingOfType<tensor::PackOp, tensor::UnPackOp, tensor::PadOp>,
+          defaultTilingOfType<TilingInterface>};
 
       for (auto &tilingFn : priorityTilingPipeLine) {
         for (auto &op : unTiledOps) {


### PR DESCRIPTION
1. Fix Pack/unPack filter logic by `getInnerDimsPos` instead of `getDimAndTileMapping`.
2. When one of multiple consumers failed to fuse, move its operand to the last in use-list in avoid of repeated attempts.
3. Split `linalgOp` and `TensorOp` tiling priority.