### PR TITLE
Bug fix for correctness check

### DIFF
--- a/lib/gc/ExecutionEngine/CPURuntime/MemoryPool.cpp
+++ b/lib/gc/ExecutionEngine/CPURuntime/MemoryPool.cpp
@@ -230,13 +230,6 @@ void FILOMemoryPool::release() {
   current = nullptr;
 }
 
-void FILOMemoryPool::clear() {
-  for (auto cur = current; cur; cur = cur->prev) {
-    cur->allocated = sizeof(MemoryBlock);
-  }
-  current = buffers;
-}
-
 FILOMemoryPool::~FILOMemoryPool() { release(); }
 
 } // namespace


### PR DESCRIPTION
This PR related to [Issue#257](https://github.com/intel/graph-compiler/issues/257#issuecomment-2295726130).
1. set unknown op as legal
2. remove unuesd clear() func