### PR TITLE
Fixed clang build

### DIFF
--- a/lib/gc/ExecutionEngine/CPURuntime/MemoryPool.cpp
+++ b/lib/gc/ExecutionEngine/CPURuntime/MemoryPool.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <cassert>
+#include <cstdint>
 #include <iostream>
 #include <memory.h>
 #include <stdexcept>


### PR DESCRIPTION
There are 2 failures when building with clang:

```
CMake Error at cmake/onednn_lite_config.cmake:208 (message):
  Unsupported Clang sanitizer ''
```

```
Cannot resolve symbol 'uint64_t'
```