### PR TITLE
Fixed imex build

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -129,11 +129,11 @@ build_llvm() {
             git fetch --all
         fi
 
-        IMEX_HASH=$(cat cmake/imex-version.txt)
+        IMEX_HASH=$(cat "$PROJECT_DIR/cmake/imex-version.txt")
         git checkout ${IMEX_HASH}
 
         cd "$llvm_dir"
-        find "$mlir_ext_dir/build_tools/patches" -name '*.patch' -exec git apply  {} +
+        find "$mlir_ext_dir/build_tools/patches" -name '*.patch' | sort -V | xargs git apply
     fi
 
     cmake -G Ninja llvm -B build \
@@ -149,7 +149,7 @@ build_llvm() {
         -DLLVM_LINK_LLVM_DYLIB=$DYN_LINK \
         -DLLVM_INCLUDE_RUNTIMES=OFF \
         -DLLVM_INCLUDE_EXAMPLES=OFF \
-        -DLLVM_INCLUDE_TESTS=OFF \
+        -DLLVM_INCLUDE_TESTS=ON \
         -DLLVM_INCLUDE_BENCHMARKS=OFF \
         -DLLVM_INCLUDE_DOCS=OFF \
         -DLLVM_INSTALL_UTILS=ON \


### PR DESCRIPTION
There are 2 issues with the current build:

1. Invalid path to imex-version.txt
2. git apply may faild if the patches are applied in an incorrect order

Also, enabled the llvm tests.