### PR TITLE
Align the bufferization pipeline according to the upstream doc

### DIFF
--- a/lib/gc/Transforms/Pipeline.cpp
+++ b/lib/gc/Transforms/Pipeline.cpp
@@ -92,6 +92,7 @@ void populateVectorPasses(mlir::OpPassManager &pm) {
 
 // scf + arith + math + vector + memref + linalg.brgemm
 void populateBufferizationPasses(mlir::OpPassManager &pm) {
+  // The flow follows https://mlir.llvm.org/docs/Bufferization/#overview
   pm.addPass(bufferization::createEmptyTensorEliminationPass());
   bufferization::OneShotBufferizationOptions options;
   options.bufferizeFunctionBoundaries = true;
@@ -111,7 +112,7 @@ void populateBufferizationPasses(mlir::OpPassManager &pm) {
   pm.addPass(bufferization::createDropEquivalentBufferResultsPass());
   pm.addNestedPass<func::FuncOp>(
       bufferization::createPromoteBuffersToStackPass());
-  mlir::bufferization::BufferDeallocationPipelineOptions deallocOption;
+  bufferization::BufferDeallocationPipelineOptions deallocOption;
   bufferization::buildBufferDeallocationPipeline(pm, deallocOption);
   pm.addPass(createBufferizationToMemRefPass());
   populateCleanUpPasses(pm);


### PR DESCRIPTION
Fix part of issue https://github.com/intel/graph-compiler/issues/288

`empty_tensor_elimination` could eliminate the copy introduced by `bufferization.materialize_in_destination`. And adjust the pipeline according to the doc(https://mlir.llvm.org/docs/Bufferization/#overview).