### PR TITLE
[Transform][Fusion] fix `getClosestExtractSliceOfOperand` when `operand` is block argument of function

### DIFF
--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -46,6 +46,8 @@ getClosestExtractSliceOfOperand(OpOperand &operand) {
     if (auto loop =
             dyn_cast<LoopLikeOpInterface>(iterArg.getOwner()->getParentOp()))
       return getClosestExtractSliceOfOperand(*loop.getTiedLoopInit(iterArg));
+    // If operand is not using loop init.
+    return failure();
   }
 
   Operation *defineOp = operand.get().getDefiningOp();


### PR DESCRIPTION
Fix #303 .