### PR TITLE
[Transform][Fusion] fix `whileProducerOutOfLoopBlock` logic

### DIFF
--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -257,8 +257,8 @@ tilingSizesIfMatchedFilter(RewriterBase &rewriter,
       if (defOrUse.isDef()) {
         SmallVector<tensor::ExtractSliceOp> backwardSlice;
         FailureOr<OpResult> realProducer =
-            scfX::getRealProducerOfExtractSliceOp(otherCandidate,
-                                                  backwardSlice);
+            scfX::getRealProducerFromExtractSliceOp(otherCandidate,
+                                                    backwardSlice);
         if (succeeded(realProducer) &&
             realProducer->getDefiningOp() == defOrUse.ownerOp)
           return failure();
@@ -476,7 +476,7 @@ tileAndFuseProducerOfOpOperand(RewriterBase &rewriter, OpOperand &operand,
   // stage, sorted from inner to outer.
   SmallVector<tensor::ExtractSliceOp> backwardSlice;
   FailureOr<OpResult> realProducer =
-      scfX::getRealProducerOfExtractSliceOp(*closestSliceOp, backwardSlice);
+      scfX::getRealProducerFromExtractSliceOp(*closestSliceOp, backwardSlice);
   if (failed(realProducer))
     return std::nullopt;
 

--- a/lib/gc/Transforms/TilingUsingInterfaceX.h
+++ b/lib/gc/Transforms/TilingUsingInterfaceX.h
@@ -18,7 +18,7 @@ SmallVector<LoopLikeOpInterface> getOuterNestLoopsWhile(
     LoopLikeOpInterface loop,
     const std::function<LogicalResult(LoopLikeOpInterface)> &pred);
 
-FailureOr<OpResult> getRealProducerOfExtractSliceOp(
+FailureOr<OpResult> getRealProducerFromExtractSliceOp(
     Operation *candidateSliceOp,
     SmallVector<tensor::ExtractSliceOp> &backwardSlice, unsigned curDepth = 0,
     unsigned maxDepth = 5);


### PR DESCRIPTION
Track #315.

BTW, the root cause is that upstream function `addInitOperandsToLoopNest` assumes nested loops must be `scf.for` instead of `scf.forall`. It may take more time to fix it upstream.