### PR TITLE
[Transform][Fusion] align file name with upstream

### DIFF
--- a/lib/gc/Transforms/CMakeLists.txt
+++ b/lib/gc/Transforms/CMakeLists.txt
@@ -13,8 +13,8 @@ gc_add_mlir_library(GcPasses
   MemRefToCPURuntime.cpp
   OneDNNGraphToLinalg.cpp
   Pipeline.cpp
+  TileUsingInterfaceX.cpp
   IterativeTilingAndFusion.cpp
-  TilingUsingInterfaceX.cpp
   VerifyTargetDescription.cpp
   DecomposeAggregatedOps.cpp
   DeepTileContractionOp.cpp

--- a/lib/gc/Transforms/IterativeTilingAndFusion.cpp
+++ b/lib/gc/Transforms/IterativeTilingAndFusion.cpp
@@ -33,7 +33,7 @@
 #include <memory>
 #include <unordered_map>
 
-#include "TilingUsingInterfaceX.h"
+#include "TileUsingInterfaceX.h"
 
 namespace mlir {
 namespace gc {

--- a/lib/gc/Transforms/Pipeline.cpp
+++ b/lib/gc/Transforms/Pipeline.cpp
@@ -56,9 +56,9 @@ void populateTensorPasses(mlir::OpPassManager &pm) {
   // linalg.matmul lowering to (scf.loop + linalg.brgemm) pass
   pm.addNestedPass<func::FuncOp>(createDeepTileContractionOp());
 
-  // Fine-grain fusion pass
+  // fine-grain fusion pass
   pm.addNestedPass<func::FuncOp>(createIterativeTilingAndFusion());
-  // todo: fine-grain fusion pass
+
   pm.addNestedPass<func::FuncOp>(
       mlir::microkernel::createConvertLinalgToMicrokernel());
   // todo: lower linalg to arith/math on virtual vector pass

--- a/lib/gc/Transforms/TileUsingInterfaceX.cpp
+++ b/lib/gc/Transforms/TileUsingInterfaceX.cpp
@@ -1,4 +1,4 @@
-//===-- TileUsingInterfaceX.cpp -  upstream eXtension ---------*- C++ -*-===//
+//===-- TileUsingInterfaceX.cpp - upstream eXtension ------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Transforms/TileUsingInterfaceX.cpp
+++ b/lib/gc/Transforms/TileUsingInterfaceX.cpp
@@ -1,4 +1,4 @@
-//===-- TilingUsingInterfaceX.cpp -  upstream eXtension ---------*- C++ -*-===//
+//===-- TileUsingInterfaceX.cpp -  upstream eXtension ---------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -26,7 +26,7 @@
 #include "llvm/Support/Debug.h"
 #include <optional>
 
-#include "TilingUsingInterfaceX.h"
+#include "TileUsingInterfaceX.h"
 
 #define DEBUG_TYPE "tile-using-interface-x"
 

--- a/lib/gc/Transforms/TileUsingInterfaceX.h
+++ b/lib/gc/Transforms/TileUsingInterfaceX.h
@@ -1,4 +1,4 @@
-//===-- TilingUsingInterfaceX.h -  upstream eXtension -----------*- C++ -*-===//
+//===-- TileUsingInterfaceX.h -  upstream eXtension -----------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TEMPORARY_TILEUSINGINTERFACE_X_H
-#define TEMPORARY_TILEUSINGINTERFACE_X_H
+#ifndef TILE_USING_INTERFACE_X_H
+#define TILE_USING_INTERFACE_X_H
 
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 

--- a/lib/gc/Transforms/TileUsingInterfaceX.h
+++ b/lib/gc/Transforms/TileUsingInterfaceX.h
@@ -1,4 +1,4 @@
-//===-- TileUsingInterfaceX.h -  upstream eXtension -----------*- C++ -*-===//
+//===-- TileUsingInterfaceX.h - upstream eXtension --------------*- C++ -*-===//
 //
 // This file is licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/lib/gc/Transforms/TilingUtil.hpp
+++ b/lib/gc/Transforms/TilingUtil.hpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef TEMPORARY_TILEUSINGINTERFACE_X_H
-#define TEMPORARY_TILEUSINGINTERFACE_X_H
+#ifndef TILING_UTIL_H
+#define TILING_UTIL_H
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -16,7 +16,7 @@
 namespace mlir {
 namespace linalgX {
 
-// An enahncement for the upstream pass to support tiling reduction for MKmk
+// An enhancement for the upstream pass to support tiling reduction for MKmk
 // like cases(with multiple reduction iterators).
 FailureOr<linalg::ForallReductionTilingResult> tileReductionUsingForall(
     RewriterBase &b, PartialReductionOpInterface op,


### PR DESCRIPTION
To distinguish two upstream file `tileUsingInterface` and `TilingInterface` and reduce confusion.