### PR TITLE
Minor build script enhancements

### DIFF
--- a/cmake/imex.cmake
+++ b/cmake/imex.cmake
@@ -14,7 +14,8 @@ if (NOT DEFINED IMEX_INCLUDES)
 
     # TODO: Change to main https://github.com/intel/mlir-extensions when all the
     # required functionality is merged.
-    gc_fetch_content(imex "${IMEX_HASH}" https://github.com/intel/mlir-extensions
+    set(IMEX_URL https://github.com/intel/mlir-extensions)
+    gc_fetch_content(imex "${IMEX_HASH}" "${IMEX_URL}"
             SET IMEX_CHECK_LLVM_VERSION=ON IMEX_ENABLE_L0_RUNTIME=0
     )
 


### PR DESCRIPTION
-  Added `-s` option for the build dir suffix.
-  Added `-v` option that allows to build LLVM only.
-  Get the IMEX repository url directly from the cmake file.
- Changed the IMEX source directory to `imex-src` - this directory is also used by cmake.

