### PR TITLE
[GPU] Automatically dump lowered mlir module on 'enableObjectDump=true'

### DIFF
--- a/lib/gc/ExecutionEngine/GPURuntime/ocl/GpuOclRuntime.cpp
+++ b/lib/gc/ExecutionEngine/GPURuntime/ocl/GpuOclRuntime.cpp
@@ -808,6 +808,10 @@ OclModuleBuilder::build(const OclRuntime::Ext &ext) {
   opts.enablePerfNotificationListener = false;
 #endif
 
+  if (enableObjectDump) {
+    mod.dump();
+  }
+
   auto eng = ExecutionEngine::create(mod, opts);
   CHECKE(eng, "Failed to create ExecutionEngine!");
   eng->get()->registerSymbols(OclRuntime::Exports::symbolMap);


### PR DESCRIPTION
`mlir::ExecutionEngine(enableObjectDump=true)` doesn't actually dump any module, but provides an ability to call `ExecutionEngine::dumpToObjectFile(...)` later (which only can dump to a file, while we want it to be dumped to std::err in OV integration).