### PR TITLE
Add kernel time tracing support for gpu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(GC_ENABLE_BINDINGS_PYTHON "Enable Graph Complier Python Binding" ON)
 option(GC_DEV_LINK_LLVM_DYLIB "Link dynamic libraries of LLVM and MLIR. For developers only. Do not use it in packing the library." OFF)
 option(GC_ENABLE_RUNTIME_NAIVE_BRGEMM "Use naive BRGEMM as runtime backend for debug purpose." OFF)
 option(GC_BENCH_ENABLE "Build benchgc." ON)
+option(GC_ENABLE_GPU_PROFILE "Enable the GPU kernel profiling." OFF)
 
 if(GC_ENABLE_LEGACY)
   add_subdirectory(legacy/core)

--- a/README.md
+++ b/README.md
@@ -77,4 +77,5 @@ Graph Compiler supports the following build-time options.
 | GC_DEV_LINK_LLVM_DYLIB    | ON, **OFF**                            | Controls dynamic link LLVM/MLIR libraries, mainly for developer |
 | GC_ENABLE_BINDINGS_PYTHON | **ON**, OFF                            | Controls building the Python API                                |
 | GC_ENABLE_IMEX            | ON, **OFF**                            | Whether to enable the GPU components                            |
+| GC_ENABLE_GPU_PROFILE     | ON, **OFF**                           | Whether to enable the GPU profiling which will profile the kernel execution time |
 

--- a/cmake/ptigpu.cmake
+++ b/cmake/ptigpu.cmake
@@ -1,0 +1,9 @@
+include_guard()
+
+FetchContent_Declare(
+  PTIGPU
+  GIT_REPOSITORY https://github.com/intel/pti-gpu.git
+  GIT_TAG        exp_opencl_0.11.0
+  SOURCE_SUBDIR  sdk
+)
+FetchContent_MakeAvailable(PTIGPU)

--- a/lib/gc/ExecutionEngine/GPURuntime/ocl/CMakeLists.txt
+++ b/lib/gc/ExecutionEngine/GPURuntime/ocl/CMakeLists.txt
@@ -8,3 +8,10 @@ gc_add_mlir_library(GcGpuOclRuntime
 )
 target_include_directories(GcGpuOclRuntime PUBLIC ${OpenCL_INCLUDE_DIRS})
 target_link_libraries(GcGpuOclRuntime PUBLIC ${OpenCL_LIBRARIES})
+
+if(GC_ENABLE_GPU_PROFILE)
+  include(ptigpu)
+  find_package(Pti REQUIRED)
+  target_link_libraries(GcGpuOclRuntime PRIVATE Pti::pti_view)
+  add_definitions(-DGC_ENABLE_GPU_PROFILE)
+endif ()

--- a/lib/gc/ExecutionEngine/GPURuntime/ocl/PtiGpuUtils.h
+++ b/lib/gc/ExecutionEngine/GPURuntime/ocl/PtiGpuUtils.h
@@ -1,0 +1,310 @@
+//===-- PtiGpuUtils.h - DESC ------------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//==============================================================
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+#ifndef SAMPLES_UTILS_H_
+#define SAMPLES_UTILS_H_
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#include "pti/pti_view.h"
+
+namespace samples_utils {
+
+inline constexpr auto kDefaultPtiBufferAlignment = std::align_val_t{1};
+
+template <typename T>
+[[nodiscard]] inline T *AlignedAlloc(std::size_t size, std::align_val_t align) {
+  return static_cast<T *>(::operator new(size, align));
+}
+
+template <typename T>
+inline void AlignedDealloc(T *buf_ptr, std::align_val_t align) {
+  ::operator delete(buf_ptr, align);
+}
+
+template <typename T> [[nodiscard]] inline T *AlignedAlloc(std::size_t size) {
+  return AlignedAlloc<T>(size, kDefaultPtiBufferAlignment);
+}
+
+template <typename T> inline void AlignedDealloc(T *buf_ptr) {
+  return AlignedDealloc<T>(buf_ptr, kDefaultPtiBufferAlignment);
+}
+
+template <typename... T> constexpr std::size_t ValidateTimestamps(T... args) {
+  using TimestampType = std::common_type_t<T...>;
+  constexpr auto count = sizeof...(args);
+  static_assert(count > 1, "Must provide more than one timestamp to validate");
+  std::size_t found_issues = 0;
+  TimestampType prev_stamp = 0;
+
+  // Use fold expressions to find issues with timestamps
+  // https://en.cppreference.com/w/cpp/language/fold
+  // this could probably be simplified if we do not care about the number of
+  // timestamp issues (we might be able to remove the lambda).
+  (
+      [&] {
+        auto next_stamp = args;
+        if (!(prev_stamp <= next_stamp)) {
+          found_issues++;
+        }
+        prev_stamp = next_stamp;
+      }(),
+      ...);
+  return found_issues;
+}
+
+//
+// Returns:    True  - if a_list passed in is a monotonically increasing
+// sequence.
+//             False - if not.
+// Assumption: Operator <= is well defined for this type already.
+//
+template <typename T> inline bool isMonotonic(std::initializer_list<T> a_list) {
+  bool current_state = true;
+  T previous = a_list.begin()[0];
+  for (auto item : a_list) {
+    current_state = current_state && (previous <= item);
+    if (!current_state)
+      return false;
+    previous = item;
+  }
+  return true;
+}
+
+std::string stringify_uuid(uint8_t *uuid, std::string additional_string) {
+  std::stringstream sstream;
+  sstream << additional_string;
+  sstream << std::hex << std::setfill('0');
+  for (uint32_t i = 1; i <= PTI_MAX_DEVICE_UUID_SIZE; ++i) {
+    sstream << std::setw(2);
+    sstream << static_cast<uint16_t>(uuid[PTI_MAX_DEVICE_UUID_SIZE - i]);
+    if (i == 4 || i == 6 || i == 8 || i == 10)
+      sstream << "-";
+  }
+  sstream << std::setfill(' ') << std::dec;
+  return sstream.str();
+}
+
+void print_uuid(uint8_t *uuid, std::string additional_string) {
+  std::cout << stringify_uuid(uuid, std::move(additional_string)) << std::endl;
+}
+
+void dump_record(pti_view_record_kernel *record) {
+  if (nullptr == record)
+    return;
+
+  std::cout << "Kernel Name: " << record->_name << '\n';
+  std::cout << "               Ze Kernel Append Time: "
+            << record->_append_timestamp << " ns" << '\n';
+  std::cout << "               Ze Kernel Submit Time: "
+            << record->_submit_timestamp << " ns" << '\n';
+  std::cout << "                Ze Kernel Start Time: "
+            << record->_start_timestamp << " ns" << '\n';
+  std::cout << "                  Ze Kernel End Time: "
+            << record->_end_timestamp << " ns" << '\n';
+  std::cout << "Kernel Queue Handle: " << record->_queue_handle << '\n';
+  std::cout << "Kernel Queue ID: " << record->_sycl_queue_id << '\n';
+  std::cout << "Kernel CommandList Context Handle: " << record->_context_handle
+            << '\n';
+  std::cout << "Kernel Id: " << std::dec << record->_kernel_id << '\n';
+  std::cout << "Correlation Id: " << std::dec << record->_correlation_id
+            << '\n';
+  std::cout << "Kernel Thread Id: " << std::dec << record->_thread_id << '\n';
+  std::cout << "         Sycl Kernel Task Begin Time: " << std::dec
+            << record->_sycl_task_begin_timestamp << " ns" << '\n';
+  std::cout << "Sycl Kernel EnqueueKernel Begin Time: " << std::dec
+            << record->_sycl_enqk_begin_timestamp << " ns" << '\n';
+  std::cout << "Kernel Execution Time: " << std::dec
+            << record->_end_timestamp - record->_start_timestamp << " ns"
+            << '\n';
+  std::cout << "Kernel File Name: " << record->_source_file_name << ":"
+            << record->_source_line_number << '\n';
+  std::cout << "Kernel Device: " << record->_pci_address << '\n';
+  print_uuid(record->_device_uuid, "Kernel Device UUID: ");
+  std::cout << "Kernel NodeID:InvocationID " << record->_sycl_node_id << ':'
+            << record->_sycl_invocation_id << '\n';
+}
+
+void dump_record(pti_view_record_memory_copy *record) {
+  if (nullptr == record)
+    return;
+
+  std::cout << "Memory Op: " << record->_name << '\n';
+  std::cout << "Memory Device: " << record->_pci_address << '\n';
+  print_uuid(record->_device_uuid, "Memory Device UUID: ");
+  std::cout << "Memory Op Execution Time: " << std::dec
+            << record->_end_timestamp - record->_start_timestamp << " ns"
+            << '\n';
+  std::cout << "               Memory Op Append Time: " << std::dec
+            << record->_append_timestamp << " ns" << '\n';
+  std::cout << "               Memory Op Submit Time: " << std::dec
+            << record->_submit_timestamp << " ns" << '\n';
+  std::cout << "                Memory Op Start Time: " << std::dec
+            << record->_start_timestamp << " ns" << '\n';
+  std::cout << "                  Memory Op End Time: " << std::dec
+            << record->_end_timestamp << " ns" << '\n';
+  std::cout << "Memory Op Queue Handle: " << record->_queue_handle << '\n';
+  std::cout << "Memory Op Queue ID: " << record->_sycl_queue_id << '\n';
+  std::cout << "Memory Op CommandList Context Handle: "
+            << record->_context_handle << '\n';
+  std::cout << "Memory Op Id: " << std::dec << record->_mem_op_id << '\n';
+  std::cout << "Memory Bytes Copied: " << std::dec << record->_bytes << '\n';
+  std::cout << "Memory Op Thread Id: " << std::dec << record->_thread_id
+            << '\n';
+  std::cout << "Correlation Id: " << std::dec << record->_correlation_id
+            << '\n';
+  std::cout << "Memory Copy Type: " << std::dec
+            << ptiViewMemcpyTypeToString(record->_memcpy_type) << '\n';
+  std::cout << "Memory Copy Source: " << std::dec
+            << ptiViewMemoryTypeToString(record->_mem_src) << '\n';
+  std::cout << "Memory Copy Destination: " << std::dec
+            << ptiViewMemoryTypeToString(record->_mem_dst) << '\n';
+}
+
+void dump_record(pti_view_record_memory_copy_p2p *record) {
+  if (nullptr == record)
+    return;
+
+  std::cout << "Memory Op: " << record->_name << '\n';
+  std::cout << "Memory Source Device: " << record->_src_pci_address << '\n';
+  std::cout << "Memory Destination Device: " << record->_dst_pci_address
+            << '\n';
+  print_uuid(record->_src_uuid, "Memory Source Device UUID: ");
+  print_uuid(record->_dst_uuid, "Memory Destination Device UUID: ");
+  std::cout << "Memory Op Execution Time: " << std::dec
+            << record->_end_timestamp - record->_start_timestamp << " ns"
+            << '\n';
+  std::cout << "               Memory Op Append Time: " << std::dec
+            << record->_append_timestamp << " ns" << '\n';
+  std::cout << "               Memory Op Submit Time: " << std::dec
+            << record->_submit_timestamp << " ns" << '\n';
+  std::cout << "                Memory Op Start Time: " << std::dec
+            << record->_start_timestamp << " ns" << '\n';
+  std::cout << "                  Memory Op End Time: " << std::dec
+            << record->_end_timestamp << " ns" << '\n';
+  std::cout << "Memory Op Queue Handle: " << record->_queue_handle << '\n';
+  std::cout << "Memory Op Queue ID: " << record->_sycl_queue_id << '\n';
+  std::cout << "Memory Op CommandList Context Handle: "
+            << record->_context_handle << '\n';
+  std::cout << "Memory Op Id: " << std::dec << record->_mem_op_id << '\n';
+  std::cout << "Memory Bytes Copied: " << std::dec << record->_bytes << '\n';
+  std::cout << "Memory Op Thread Id: " << std::dec << record->_thread_id
+            << '\n';
+  std::cout << "Correlation Id: " << std::dec << record->_correlation_id
+            << '\n';
+  std::cout << "Memory Copy Type: " << std::dec
+            << ptiViewMemcpyTypeToString(record->_memcpy_type) << '\n';
+  std::cout << "Memory Copy Source: " << std::dec
+            << ptiViewMemoryTypeToString(record->_mem_src) << '\n';
+  std::cout << "Memory Copy Destination: " << std::dec
+            << ptiViewMemoryTypeToString(record->_mem_dst) << '\n';
+}
+
+void dump_record(pti_view_record_memory_fill *record) {
+  if (nullptr == record)
+    return;
+
+  std::cout << "Memory Op: " << record->_name << '\n';
+  std::cout << "Memory Device: " << record->_pci_address << '\n';
+  print_uuid(record->_device_uuid, "Memory Device UUID: ");
+  std::cout << "Memory Op Execution Time: " << std::dec
+            << record->_end_timestamp - record->_start_timestamp << " ns"
+            << '\n';
+  std::cout << "               Memory Op Append Time: " << std::dec
+            << record->_append_timestamp << " ns" << '\n';
+  std::cout << "               Memory Op Submit Time: " << std::dec
+            << record->_submit_timestamp << " ns" << '\n';
+  std::cout << "                Memory Op Start Time: " << std::dec
+            << record->_start_timestamp << " ns" << '\n';
+  std::cout << "                  Memory Op End Time: " << std::dec
+            << record->_end_timestamp << " ns" << '\n';
+  std::cout << "Memory Op Queue Handle: " << record->_queue_handle << '\n';
+  std::cout << "Memory Op Queue ID: " << record->_sycl_queue_id << '\n';
+  std::cout << "Memory Op CommandList Context Handle: "
+            << record->_context_handle << '\n';
+  std::cout << "Memory Op Id: " << std::dec << record->_mem_op_id << '\n';
+  std::cout << "Memory Op Thread Id: " << std::dec << record->_thread_id
+            << '\n';
+  std::cout << "Memory Bytes Transfered: " << record->_bytes << '\n';
+  std::cout << "Memory Value for Set: " << record->_value_for_set << '\n';
+  std::cout << "Correlation Id: " << std::dec << record->_correlation_id
+            << '\n';
+  std::cout << "Memory Fill Type: " << std::dec << record->_mem_type << '\n';
+}
+
+void dump_record(pti_view_record_zecalls *record) {
+  if (nullptr == record)
+    return;
+  const char *pName = nullptr;
+  ptiViewGetCallbackIdName(record->_callback_id, &pName);
+  std::cout << "ZeCall Function Name: " << pName << '\n';
+  std::cout << "ZeCall Function CBID: " << record->_callback_id << '\n';
+  std::cout << "ZeCall Start Time: " << record->_start_timestamp << '\n';
+  std::cout << "  ZeCall End Time: " << record->_end_timestamp << '\n';
+  std::cout << "ZeCall Process Id: " << record->_process_id << '\n';
+  std::cout << "ZeCall Thread Id: " << record->_thread_id << '\n';
+  std::cout << "ZeCall Correlation Id: " << record->_correlation_id << '\n';
+}
+
+void dump_record(pti_view_record_oclcalls *record) {
+  if (nullptr == record)
+    return;
+  const char *name = nullptr;
+  ptiViewGetCallbackIdName(record->_callback_id, &name);
+  std::cout << "OclCall Function Name: " << name << '\n';
+  std::cout << "OclCall Function CBID: " << record->_callback_id << '\n';
+  std::cout << "OclCall Start Time: " << record->_start_timestamp << '\n';
+  std::cout << "  OclCall End Time: " << record->_end_timestamp << '\n';
+  std::cout << "OclCall Process Id: " << record->_process_id << '\n';
+  std::cout << "OclCall Thread Id: " << record->_thread_id << '\n';
+  std::cout << "OclCall Correlation Id: " << record->_correlation_id << '\n';
+}
+
+void dump_record(pti_view_record_sycl_runtime *record) {
+  if (nullptr == record)
+    return;
+  std::cout << "Sycl Function Name: " << record->_name << '\n';
+  std::cout << "Sycl Start Time: " << record->_start_timestamp << '\n';
+  std::cout << "Sycl End Time: " << record->_end_timestamp << '\n';
+  std::cout << "Sycl Process Id: " << record->_process_id << '\n';
+  std::cout << "Sycl Thread Id: " << record->_thread_id << '\n';
+  std::cout << "Sycl Correlation Id: " << record->_correlation_id << '\n';
+}
+
+void dump_record(pti_view_record_overhead *record) {
+  if (nullptr == record)
+    return;
+  std::cout << "Overhead Kind : "
+            << ptiViewOverheadKindToString(record->_overhead_kind) << '\n';
+  std::cout << "Overhead Time Duration(ns): " << record->_overhead_duration_ns
+            << '\n';
+  std::cout << "Overhead Count: " << record->_overhead_count << '\n';
+  std::cout << "Overhead ApiId: " << record->_api_id << '\n';
+  std::cout << "Overhead Start Timestamp(ns): "
+            << record->_overhead_start_timestamp_ns << '\n';
+  std::cout << "Overhead End Timestamp(ns): "
+            << record->_overhead_end_timestamp_ns << '\n';
+  std::cout << "Overhead ThreadId: " << record->_overhead_thread_id << '\n';
+  // std::cout << "Overhead API Responsible : "
+  //<< record->_overhead_api_name << '\n';
+}
+
+void dump_record(pti_view_record_external_correlation *record) {
+  if (nullptr == record)
+    return;
+  std::cout << "External Correlation Kind : " << record->_external_kind << '\n';
+  std::cout << "Correlation Id: " << record->_correlation_id << '\n';
+  std::cout << "External Id: " << record->_external_id << '\n';
+}
+} // namespace samples_utils
+#endif


### PR DESCRIPTION
Use [pti-gpu](https://github.com/intel/pti-gpu) to trace the OpenCL kernel execution and print the trace result after the program is finished. The feature is default OFF and could be enable by setting `-DGC_ENABLE_GPU_PROFILE=ON`.

**Example**:
```
./bin/gc-gpu-runner --shared-libs=../externals/llvm-project/build/lib/libmlir_runner_utils.so ../test/mlir/test/gc/gpu-runner/XeGPU/f16_matmul_128x64_transpose.mlir

Unranked Memref base@ = 0x556fbba18bc0 rank = 1 offset = 0 sizes = [32] strides = [64] data = 
[5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719,  5.11719]

=== API Timing Results: ===

             Total Execution Time (ns):             63061619
Total API Time for CL CPU backend (ns):                 3418
Total API Time for CL GPU backend (ns):              1952063

== CL CPU Backend: ==

      Function,       Calls,           Time (ns),  Time (%),        Average (ns),            Min (ns),            Max (ns)
clGetDeviceIDs,           1,                3418,    100.00,                3418,                3418,                3418

== CL GPU Backend: ==

                                Function,       Calls,           Time (ns),  Time (%),        Average (ns),            Min (ns),            Max (ns)
                    clEnqueueMemcpyINTEL,           4,             1111814,     56.96,              277953,               12439,              877623
                  clEnqueueNDRangeKernel,           1,              181885,      9.32,              181885,              181885,              181885
                          clBuildProgram,           1,              166584,      8.53,              166584,              166584,              166584
                         clWaitForEvents,           2,              142960,      7.32,               71480,               18542,              124418
      clCreateCommandQueueWithProperties,           1,              113511,      5.81,              113511,              113511,              113511
                   clSharedMemAllocINTEL,           3,              106677,      5.46,               35559,               14840,               70172
                          clMemFreeINTEL,           3,               71023,      3.64,               23674,               15496,               39005
                         clCreateContext,           1,               15468,      0.79,               15468,               15468,               15468
                        clReleaseProgram,           1,                7996,      0.41,                7996,                7996,                7996
           clSetKernelArgMemPointerINTEL,           3,                6909,      0.35,                2303,                1240,                4271
                          clCreateKernel,           1,                6202,      0.32,                6202,                6202,                6202
                   clCreateProgramWithIL,           1,                5263,      0.27,                5263,                5263,                5263
                          clReleaseEvent,           5,                2464,      0.13,                 492,                 214,                1222
clGetExtensionFunctionAddressForPlatform,           6,                2361,      0.12,                 393,                 233,                 660
                         clReleaseKernel,           2,                2077,      0.11,                1038,                 552,                1525
                          clGetDeviceIDs,           2,                1922,      0.10,                 961,                 206,                1716
                          clSetKernelArg,           7,                1670,      0.09,                 238,                  53,                1038
                           clCloneKernel,           1,                1485,      0.08,                1485,                1485,                1485
                   clReleaseCommandQueue,           1,                1332,      0.07,                1332,                1332,                1332
                         clGetDeviceInfo,           4,                 979,      0.05,                 244,                  64,                 527
                   clGetCommandQueueInfo,           4,                 937,      0.05,                 234,                  49,                 550
                     clSetKernelExecInfo,           3,                 544,      0.03,                 181,                  69,                 405


=== Device Timing Results: ===

                Total Execution Time (ns):             63061619
Total Device Time for CL GPU backend (ns):                95680

== CL GPU Backend: ==

              Kernel,       Calls,           Time (ns),    Time (%),        Average (ns),            Min (ns),            Max (ns)
linalg_matmul_kernel,           1,               95680,      100.00,               95680,               95680,               95680

```