### PR TITLE
[GPU] XeVM to LLVM pass structure

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -119,6 +119,16 @@ function(gc_add_mlir_dialect_library name)
     endif()
 endfunction()
 
+function(gc_add_mlir_conversion_library name)
+    add_mlir_conversion_library(${ARGV})
+    target_link_libraries(obj.${name} PUBLIC GcInterface)
+    set_property(GLOBAL APPEND PROPERTY GC_PASS_LIBS ${name})
+
+    if(GcInterface IN_LIST ARGN)
+        target_link_libraries(obj.${name} PUBLIC GcInterface)
+    endif()
+endfunction()
+
 macro(gc_add_mlir_tool name)
     # the dependency list copied from mlir/tools/mlir-cpu-runner/CMakeLists.txt of upstream
     if(NOT DEFINED LLVM_LINK_COMPONENTS)

--- a/include/gc/CMakeLists.txt
+++ b/include/gc/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Dialect)
 add_subdirectory(Transforms)
+add_subdirectory(Conversion)

--- a/include/gc/Conversion/CMakeLists.txt
+++ b/include/gc/Conversion/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name GCConversion)
+mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix GCConversion)
+mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix GCConversion)
+add_public_tablegen_target(GCConversionPassIncGen)
+
+add_mlir_doc(Passes GCConversionPasses ./ -gen-pass-doc)

--- a/include/gc/Conversion/Passes.h
+++ b/include/gc/Conversion/Passes.h
@@ -1,0 +1,22 @@
+//===-- Passes.h - Conversion Passes  ---------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef GC_CONVERSION_PASSES_H
+#define GC_CONVERSION_PASSES_H
+
+#include "gc/Conversion/XeVMToLLVM.h"
+
+namespace mlir {
+
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "gc/Conversion/Passes.h.inc"
+
+} // namespace mlir
+
+#endif // GC_CONVERSION_PASSES_H

--- a/include/gc/Conversion/Passes.td
+++ b/include/gc/Conversion/Passes.td
@@ -1,0 +1,25 @@
+//===-- Passes.td - Conversion pass definition file --------*- tablegen -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef GC_CONVERSION_PASSES
+#define GC_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+//===----------------------------------------------------------------------===//
+// XeVMToLLVM
+//===----------------------------------------------------------------------===//
+
+def ConvertXeVMToLLVMPass : Pass<"convert-xevm-to-llvm"> {
+  let summary = "Convert XeVM to LLVM dialect";
+  let dependentDialects = [
+    "xevm::XeVMDialect",
+  ];
+}
+
+#endif // GC_CONVERSION_PASSES

--- a/include/gc/Conversion/XeVMToLLVM/XeVMToLLVM.h
+++ b/include/gc/Conversion/XeVMToLLVM/XeVMToLLVM.h
@@ -1,0 +1,28 @@
+//===-- XeVMToLLVM.h - Convert XeVM to LLVM dialect -------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#ifndef MLIR_CONVERSION_XEVMTOLLVM_XEVMTOLLVMPASS_H_
+#define MLIR_CONVERSION_XEVMTOLLVM_XEVMTOLLVMPASS_H_
+
+#include <memory>
+
+namespace mlir {
+class DialectRegistry;
+class LLVMTypeConverter;
+class RewritePatternSet;
+class Pass;
+
+#define GEN_PASS_DECL_CONVERTXEVMTOLLVMPASS
+#include "mlir/Conversion/Passes.h.inc"
+
+void populateXeVMToLLVMConversionPatterns(RewritePatternSet &patterns);
+
+void registerConvertXeVMToLLVMInterface(DialectRegistry &registry);
+
+} // namespace mlir
+
+#endif // MLIR_CONVERSION_XEVMTOLLVM_XEVMTOLLVMPASS_H_

--- a/lib/gc/CMakeLists.txt
+++ b/lib/gc/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(Analysis)
 add_subdirectory(CAPI)
+add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(Transforms)
 add_subdirectory(ExecutionEngine)

--- a/lib/gc/Conversion/CMakeLists.txt
+++ b/lib/gc/Conversion/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(XeVMToLLVM)

--- a/lib/gc/Conversion/XeVMToLLVM/CMakeLists.txt
+++ b/lib/gc/Conversion/XeVMToLLVM/CMakeLists.txt
@@ -1,0 +1,21 @@
+gc_add_mlir_conversion_library(MLIRXeVMToLLVM
+  XeVMToLLVM.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/gc/Conversion/XeVMToLLVM
+
+  DEPENDS
+  GCConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRFuncDialect
+  MLIRGPUDialect
+  MLIRLLVMCommonConversion
+  MLIRLLVMDialect
+  MLIRXeVMDialect
+  MLIRPass
+  MLIRTransforms
+)

--- a/lib/gc/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
+++ b/lib/gc/Conversion/XeVMToLLVM/XeVMToLLVM.cpp
@@ -1,0 +1,55 @@
+//===-- XeVMToLLVM.cpp - XeVM to LLVM dialect conversion --------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gc/Conversion/XeVMToLLVM/XeVMToLLVM.h"
+
+#include "gc/Dialect/LLVMIR/XeVMDialect.h"
+#include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+
+#define DEBUG_TYPE "xevm-to-llvm"
+
+namespace mlir {
+#define GEN_PASS_DEF_CONVERTXEVMTOLLVMPASS
+#include "gc/Conversion/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+using namespace xevm;
+
+namespace {
+struct ConvertXeVMToLLVMPass
+    : public impl::ConvertXeVMToLLVMPassBase<ConvertXeVMToLLVMPass> {
+  using Base::Base;
+
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<LLVM::LLVMDialect, xevm::XeVMDialect>();
+  }
+
+  void runOnOperation() override {
+    ConversionTarget target(getContext());
+    target.addLegalDialect<::mlir::LLVM::LLVMDialect>();
+    RewritePatternSet pattern(&getContext());
+    mlir::populateXeVMToLLVMConversionPatterns(pattern);
+    if (failed(
+            applyPartialConversion(getOperation(), target, std::move(pattern))))
+      signalPassFailure();
+  }
+};
+} // namespace
+
+void mlir::populateXeVMToLLVMConversionPatterns(RewritePatternSet &patterns) {
+  /*TODO*/
+}
+
+void mlir::registerConvertXeVMToLLVMInterface(DialectRegistry &registry) {
+  /*TODO*/
+}


### PR DESCRIPTION
This adds the lowering pass boilerplate for `convert-xevm-to-llvm`.

Depends on #390.