### PR TITLE
[LinalgToXeGPU] Support squeezable any-D memrefs

### DIFF
--- a/include/gc/Transforms/Utils/ValueUtils.h
+++ b/include/gc/Transforms/Utils/ValueUtils.h
@@ -53,6 +53,27 @@ Value flattenMemref(PatternRewriter &rewriter, Location loc, Value srcMemref);
 // Return true if the memref has shared memory space.
 bool hasSharedMemSpace(mlir::Value memref);
 
+// Go through all parent 'memref.subview' ops for the given `memref`
+// and return the folded offsets of all subviews and the root memref.
+std::tuple<SmallVector<Value>, Value>
+computeSubviewOffsets(PatternRewriter &rewriter, Location loc, Value memref);
+
+// Return the strides of the memref
+SmallVector<OpFoldResult> getMemrefStrides(PatternRewriter &rewriter,
+                                           Location loc, Value memref);
+
+// Squeeze the leading dimensions of a given memref up to 'maxDims'.
+FailureOr<Value> squeezeMemref(PatternRewriter &rewriter, Location loc,
+                               Value memref, size_t maxDims = 2);
+
+// Squeeze the leading dimensions of memref operands of a given 'linalgOp'.
+LogicalResult maybeSqueezeDims(PatternRewriter &rewriter,
+                               linalg::LinalgOp linalgOp, size_t maxDims = 2);
+
+// Return if a memref with the given shape can be squeezed to the shape of
+// 'maxDims'. Only leading dimensions are considered squeezable.
+bool canSqueezeDims(llvm::ArrayRef<int64_t> shape, size_t maxDims = 2);
+
 } // namespace utils
 } // namespace mlir
 

--- a/include/gc/Transforms/Utils/ValueUtils.h
+++ b/include/gc/Transforms/Utils/ValueUtils.h
@@ -55,8 +55,9 @@ bool hasSharedMemSpace(mlir::Value memref);
 
 // Go through all parent 'memref.subview' ops for the given `memref`
 // and return the folded offsets of all subviews and the root memref.
-std::tuple<SmallVector<Value>, Value>
-computeSubviewOffsets(PatternRewriter &rewriter, Location loc, Value memref);
+void computeSubviewOffsets(PatternRewriter &rewriter, Location loc,
+                           Value memref, SmallVector<Value> &resultOffsets,
+                           Value &resultRootMemref);
 
 // Return the strides of the memref
 SmallVector<OpFoldResult> getMemrefStrides(PatternRewriter &rewriter,

--- a/include/gc/Transforms/Utils/ValueUtils.h
+++ b/include/gc/Transforms/Utils/ValueUtils.h
@@ -64,8 +64,8 @@ SmallVector<OpFoldResult> getMemrefStrides(PatternRewriter &rewriter,
                                            Location loc, Value memref);
 
 // Squeeze the leading dimensions of a given memref up to 'maxDims'.
-FailureOr<Value> squeezeMemref(PatternRewriter &rewriter, Location loc,
-                               Value memref, size_t maxDims = 2);
+FailureOr<Value> reduceMemrefDims(PatternRewriter &rewriter, Location loc,
+                                  Value memref, size_t maxDims = 2);
 
 // Squeeze the leading dimensions of memref operands of a given 'linalgOp'.
 LogicalResult maybeSqueezeDims(PatternRewriter &rewriter,

--- a/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
+++ b/lib/gc/Transforms/GPU/LinalgToXeGPU.cpp
@@ -835,10 +835,12 @@ static SmallVector<Value> createSLMDescTiles(PatternRewriter &rewriter,
   auto srcType = cast<MemRefType>(src.getType());
   assert(srcType.getRank() == 2 && "Expected a 2D memref");
 
+  SmallVector<Value> offsets;
+  Value rootMemref;
   // 'imex::ConvertGPUXToSPIRVPass' doesn't allow 'memref.subview' ops in the
   // GPU kernel. We have to merge the subview offsets into the descriptor
   // offset.
-  auto [offsets, rootMemref] = utils::computeSubviewOffsets(rewriter, loc, src);
+  utils::computeSubviewOffsets(rewriter, loc, src, offsets, rootMemref);
   auto rootStridesFold = utils::getMemrefStrides(rewriter, loc, rootMemref);
   auto rootStrides =
       getValueOrCreateConstantIndexOp(rewriter, loc, rootStridesFold);

--- a/lib/gc/Transforms/Utils/ValueUtils.cpp
+++ b/lib/gc/Transforms/Utils/ValueUtils.cpp
@@ -285,10 +285,8 @@ LogicalResult maybeSqueezeDims(PatternRewriter &rewriter,
     auto operand = operands[i];
     auto type = dyn_cast<MemRefType>(operand.getType());
     if (!type) {
-      // maybe should 'continue' here instead and skip non-memref operands?
-      // TODO: replace this with 'continue' if such case would appear someday
-      return rewriter.notifyMatchFailure(
-          linalgOp, "Expect memref operand for XeGPU lowering");
+      // Skip non-memref operands
+      continue;
     }
 
     if (type.getShape().size() <= maxDims)

--- a/lib/gc/Transforms/Utils/ValueUtils.cpp
+++ b/lib/gc/Transforms/Utils/ValueUtils.cpp
@@ -306,6 +306,9 @@ LogicalResult maybeSqueezeDims(PatternRewriter &rewriter,
     newOperands.emplace_back(i, flatSubview);
   }
 
+  if (newOperands.empty())
+    return success();
+
   rewriter.modifyOpInPlace(linalgOp, [&] {
     for (auto [i, operand] : newOperands)
       linalgOp->setOperand(i, operand);

--- a/lib/gc/Transforms/Utils/ValueUtils.cpp
+++ b/lib/gc/Transforms/Utils/ValueUtils.cpp
@@ -216,7 +216,7 @@ computeSubviewOffsets(PatternRewriter &rewriter, Location loc, Value memref) {
     memref = subViewOp.getOperand(0);
   }
 
-  return std::make_tuple(resolvedOffsets, memref);
+  return std::make_tuple(std::move(resolvedOffsets), memref);
 }
 
 SmallVector<OpFoldResult> getMemrefStrides(PatternRewriter &rewriter,

--- a/lib/gc/Transforms/Utils/ValueUtils.cpp
+++ b/lib/gc/Transforms/Utils/ValueUtils.cpp
@@ -6,10 +6,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <numeric>
+
+#include "mlir/Dialect/Affine/ViewLikeInterfaceUtils.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/MemRef/Utils/MemRefUtils.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Matchers.h"
@@ -155,9 +159,10 @@ Value flattenMemref(PatternRewriter &rewriter, Location loc, Value srcMemref) {
   auto srcType = cast<MemRefType>(srcMemref.getType());
 
   assert(srcType && "Expected a memref type");
-  assert(srcType.getRank() == 2 && "Expected a 2D memref");
 
-  int64_t flatSize = srcType.getShape()[0] * srcType.getShape()[1];
+  auto shapeNd = srcType.getShape();
+  int64_t flatSize =
+      std::accumulate(shapeNd.begin(), shapeNd.end(), 1, std::multiplies<>());
 
   Value offset = rewriter.create<arith::ConstantIndexOp>(loc, 0);
   Value size = rewriter.create<arith::ConstantIndexOp>(loc, flatSize);
@@ -191,6 +196,129 @@ bool hasSharedMemSpace(mlir::Value memref) {
            static_cast<int64_t>(mlir::gpu::AddressSpace::Private);
 
   return false;
+}
+
+std::tuple<SmallVector<Value>, Value>
+computeSubviewOffsets(PatternRewriter &rewriter, Location loc, Value memref) {
+  auto fillVal = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+  auto origShape = dyn_cast<MemRefType>(memref.getType()).getShape();
+
+  SmallVector<Value> resolvedOffsets(origShape.size(), fillVal);
+
+  while (auto subViewOp = memref.getDefiningOp<memref::SubViewOp>()) {
+    auto currentOffsets = getAsOpFoldResult(resolvedOffsets);
+    resolvedOffsets.clear();
+
+    affine::resolveIndicesIntoOpWithOffsetsAndStrides(
+        rewriter, memref.getLoc(), subViewOp.getMixedOffsets(),
+        subViewOp.getMixedStrides(), subViewOp.getDroppedDims(), currentOffsets,
+        resolvedOffsets);
+    memref = subViewOp.getOperand(0);
+  }
+
+  return std::make_tuple(resolvedOffsets, memref);
+}
+
+SmallVector<OpFoldResult> getMemrefStrides(PatternRewriter &rewriter,
+                                           Location loc, Value memref) {
+  auto type = dyn_cast<MemRefType>(memref.getType());
+
+  auto stridedLayout = dyn_cast<StridedLayoutAttr>(type.getLayout());
+  if (stridedLayout) {
+    auto strides = stridedLayout.getStrides();
+    return getMixedValues(strides, {}, rewriter);
+  }
+
+  auto sizes = getMixedValues(type.getShape(), {}, rewriter);
+  auto strides = memref::computeStridesIRBlock(loc, rewriter, sizes);
+  return strides;
+}
+
+FailureOr<Value> squeezeMemref(PatternRewriter &rewriter, Location loc,
+                               Value memref, size_t maxDims = 2) {
+  auto type = dyn_cast<MemRefType>(memref.getType());
+  auto shape = type.getShape();
+
+  if (shape.size() <= maxDims)
+    return memref;
+
+  for (size_t i = 0; i < shape.size() - maxDims; i++)
+    if (shape[i] != 1)
+      return failure();
+
+  auto offsets =
+      getMixedValues(SmallVector<int64_t>(shape.size(), 0), {}, rewriter);
+  auto sizes = getMixedValues(shape, {}, rewriter);
+  auto staticStrides = utils::getStaticStrides(memref).value();
+  auto strides =
+      getMixedValues(SmallVector<int64_t>(shape.size(), 1), {}, rewriter);
+
+  SmallVector<int64_t> newShape(shape.begin() + shape.size() - maxDims,
+                                shape.end());
+  SmallVector<int64_t> newStrides(
+      staticStrides.begin() + shape.size() - maxDims, staticStrides.end());
+
+  int64_t newOffset = 0;
+  if (auto memrefLayout = dyn_cast<StridedLayoutAttr>(type.getLayout()))
+    newOffset = memrefLayout.getOffset();
+
+  auto newLayout = StridedLayoutAttr::get(
+      rewriter.getContext(), /*offset=*/newOffset, /*strides=*/newStrides);
+  MemRefType newMemRefType = MemRefType::get(newShape, type.getElementType(),
+                                             newLayout, type.getMemorySpace());
+
+  auto squeezedSubview =
+      rewriter
+          .create<memref::SubViewOp>(loc, newMemRefType, memref, offsets, sizes,
+                                     strides)
+          .getResult();
+  return squeezedSubview;
+}
+
+LogicalResult maybeSqueezeDims(PatternRewriter &rewriter,
+                               linalg::LinalgOp linalgOp, size_t maxDims) {
+  SmallVector<std::pair<size_t, Value>> newOperands;
+  auto operands = linalgOp->getOperands();
+  auto loc = linalgOp.getLoc();
+
+  for (size_t i = 0; i < operands.size(); i++) {
+    auto operand = operands[i];
+    auto type = dyn_cast<MemRefType>(operand.getType());
+    if (!type) {
+      // maybe should 'continue' here instead and skip non-memref operands?
+      // TODO: replace this with 'continue' if such case would appear someday
+      return rewriter.notifyMatchFailure(
+          linalgOp, "Expect memref operand for XeGPU lowering");
+    }
+
+    if (type.getShape().size() <= maxDims)
+      continue;
+
+    auto res = squeezeMemref(rewriter, loc, operand, maxDims);
+    if (failed(res)) {
+      return rewriter.notifyMatchFailure(
+          linalgOp, "Can't squeeze memref to the desired number of dimensions");
+    }
+
+    auto flatSubview = res.value();
+    newOperands.emplace_back(i, flatSubview);
+  }
+
+  for (auto [i, operand] : newOperands)
+    linalgOp->setOperand(i, operand);
+
+  return success();
+}
+
+bool canSqueezeDims(llvm::ArrayRef<int64_t> shape, size_t maxDims) {
+  if (shape.size() <= maxDims)
+    return true;
+
+  for (size_t i = 0; i < shape.size() - maxDims; i++)
+    if (shape[i] != 1)
+      return false;
+
+  return true;
 }
 
 } // namespace utils

--- a/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu-squeeze.mlir
+++ b/test/mlir/test/gc/Transforms/GPU/linalg-to-xegpu-squeeze.mlir
@@ -1,0 +1,61 @@
+// RUN: gc-opt %s -linalg-to-xegpu="dpas-tile=8,16,16 k-tile=16" -canonicalize -split-input-file -cse | FileCheck %s
+
+!input_type = memref<2x4x8x16xf16>
+!chunk_type = memref<1x1x8x16xf16, strided<[512, 128, 16, 1], offset: ?>>
+!slm_chunk = memref<1x1x8x16xf16, strided<[128, 128, 16, 1], offset: ?>, 3>
+
+// The map that computes an offset for SLM
+// CHECK: #map = affine_map<(d0, d1) -> (d0 * 4 + d1)>
+#map = affine_map<(xi, yi) -> (xi * 4 + yi)>
+
+func.func @entry(%arg0: !input_type, %arg1: !input_type, %arg2: !input_type) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c4 = arith.constant 4 : index
+
+  gpu.launch blocks(%arg3, %arg4, %arg5) in (%arg9 = %c1, %arg10 = %c1, %arg11 = %c1) threads(%arg6, %arg7, %arg8) in (%arg12 = %c2, %arg13 = %c4, %arg14 = %c1) {
+    // CHECK: %[[ARG0_SB:.+]] = memref.subview %arg0[%arg6, %arg7, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1]
+    %arg0_sb = memref.subview %arg0[%arg6, %arg7, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : !input_type to !chunk_type
+    // CHECK: %[[ARG1_SB:.+]] = memref.subview %arg1[%arg6, %arg7, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1]
+    %arg1_sb = memref.subview %arg1[%arg6, %arg7, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : !input_type to !chunk_type
+    // CHECK: %[[ARG2_SB:.+]] = memref.subview %arg2[%arg6, %arg7, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1]
+    %arg2_sb = memref.subview %arg2[%arg6, %arg7, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : !input_type to !chunk_type
+
+    // CHECK: %[[SLM_BUFF:.+]] = memref.alloc() : memref<8x1x8x16xf16, 3>
+    %slm_root = memref.alloc() : memref<8x1x8x16xf16, 3>
+
+    %slm_idx = affine.apply #map(%arg6, %arg7)
+    %slm = memref.subview %slm_root[%slm_idx, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : memref<8x1x8x16xf16, 3> to !slm_chunk
+
+    // Squeezing the arguments of 'linalg.mul'
+    // CHECK: %[[ARG0_SQUEEZ:.+]] = memref.subview %[[ARG0_SB]][0, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] :
+    // CHECK-SAME: memref<1x1x8x16xf16, strided<[512, 128, 16, 1], offset: ?>> to memref<8x16xf16, strided<[16, 1], offset: ?>>
+
+    // CHECK: %[[ARG1_SQUEEZ:.+]] = memref.subview %[[ARG1_SB]][0, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] :
+    // CHECK-SAME: memref<1x1x8x16xf16, strided<[512, 128, 16, 1], offset: ?>> to memref<8x16xf16, strided<[16, 1], offset: ?>>
+
+    // Verify that tensor descriptors are created from the squeezed memrefs
+    // CHECK: xegpu.create_nd_tdesc %[[ARG0_SQUEEZ]]
+    // CHECK: xegpu.create_nd_tdesc %[[ARG1_SQUEEZ]]
+
+    // Verify that the SLM output of linalg.mul is squeezed correctly
+    // CHECK-NOT: .* = memref.subview %[[SLM_BUFF]] .*
+    // CHECK: %[[SLM_THREAD_OFF:.+]] = affine.apply #map(%arg6, %arg7)
+    // CHECK: %[[SLM_OFF:.+]] = arith.muli %[[SLM_THREAD_OFF]], %c128 : index
+    // CHECK: %[[FLAT_SLM:.+]] = memref.reinterpret_cast %[[SLM_BUFF]] to offset: [%c0], sizes: [%c1024], strides: [%c1] : memref<8x1x8x16xf16, 3> to memref<1024xf16, 3>
+    // CHECK: xegpu.create_tdesc %[[FLAT_SLM]]
+    linalg.mul ins(%arg0_sb, %arg1_sb : !chunk_type, !chunk_type) outs(%slm : !slm_chunk)
+
+    // Squeezing the result buffer of 'linalg.add'
+    // CHECK: %[[ARG2_SQUEEZ:.+]] = memref.subview %[[ARG2_SB]][0, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] :
+    // CHECK-SAME: memref<1x1x8x16xf16, strided<[512, 128, 16, 1], offset: ?>> to memref<8x16xf16, strided<[16, 1], offset: ?>>
+
+    // Verify that tensor descriptors are created from the squeezed memrefs
+    // CHECK: xegpu.create_nd_tdesc %[[ARG2_SQUEEZ]]
+    linalg.add ins(%arg0_sb, %slm : !chunk_type, !slm_chunk) outs(%arg2_sb : !chunk_type)
+
+    gpu.terminator
+  } {SCFToGPU_visited}
+
+  return
+}


### PR DESCRIPTION
This PR allows any-D memrefs to be used in `linalg-to-xegpu` pass as long they can be squeezed to a 2D memref through leading dimensions. Example: 
```mlir
// allowed
!chunk_type = memref<1x1x8x16xf16, strided<[512, 128, 16, 1], offset: ?>>
linalg.mul ins(%0, %1 : !chunk_type, !chunk_type) outs(%2 : !chunk_type)

// NOT allowed
!chunk_type = memref<1x8x1x16xf16, strided<[512, 128, 16, 1], offset: ?>>
linalg.mul ins(%0, %1 : !chunk_type, !chunk_type) outs(%2 : !slm_chunk)
```

The `linalg-to-xegpu` logic considers a linalg operation that can be lowered to xegpu and checks the operand shapes. The old logic refused all `linalgOps` that have non-2D operands. The new logic additionally checks if a non-2D operand can be squeezed to a 2D and allows them if they can. It then squeezes the non-2D operand using `memref.subview` and replaces old operands with new 2D memrefs. Example:
```mlir
// input:
!chunk_type = memref<1x1x8x16xf16, strided<[512, 128, 16, 1], offset: ?>>
linalg.mul ins(%0, %1 : !chunk_type, !chunk_type) outs(%2 : !chunk_type)

// output:
!chunk_type = memref<1x1x8x16xf16, strided<[512, 128, 16, 1], offset: ?>>
!squeezed_type = memref<8x16xf16, strided<[16, 1], offset: ?>>

%0_sq = memref.subview %0[0, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : !chunk_type to !squeezed_type
%1_sq = memref.subview %1[0, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : !chunk_type to !squeezed_type
%2_sq = memref.subview %2[0, 0, 0, 0] [1, 1, 8, 16] [1, 1, 1, 1] : !chunk_type to !squeezed_type
linalg.mul ins(%0_sq, %1_sq : !squeezed_type , !squeezed_type ) outs(%2_sq : !squeezed_type )
```