### PR TITLE
[GpuTilingAndFusion] Add support for squeezing.

### DIFF
--- a/lib/gc/Transforms/GPU/GpuTilingAndFusion.cpp
+++ b/lib/gc/Transforms/GPU/GpuTilingAndFusion.cpp
@@ -101,17 +101,16 @@ private:
           auto sizePerThread = numIterations / numThreads * elementSize;
           auto totalSize = std::max(sizePerThread, cachePerThread);
           totalSize = std::max(totalSize / elementSize, 64L);
-          int64_t minTileSize = 1;
+          auto xeGpu = canLowerToXeGPU(op);
 
           // If the operation could be lowered to XeGPU, make the tiles
-          // multiple of the vector width and the minimum tile size 8.
-          if (canLowerToXeGPU(op)) {
-            minTileSize = 8;
+          // multiple of the vector width.
+          if (xeGpu) {
             totalSize = std::max(totalSize / vectorWidth, 1L) * vectorWidth;
           }
 
           SmallVector<int64_t> tiles = sizes;
-          adjustTiles(totalSize, tiles, minTileSize);
+          adjustTiles(totalSize, tiles, xeGpu);
 
           // If the tiles are equal to the sizes, split the largest tile
           // to avoid loops elimination by the canonicalizer pass.
@@ -356,16 +355,12 @@ private:
         return false;
       }
 
-      auto shape = type.getShape();
-      if (isOutput) {
-        if (shape.size() != 2 || shape[0] * shape[1] < 16) {
-          return false;
-        }
-      } else if (shape.size() > 2) {
-        return false;
+      if (auto shape = type.getShape(); shape.size() >= 2) {
+        return !isOutput ||
+               std::accumulate(shape.begin() + 1, shape.end(), shape[0],
+                               std::multiplies<>()) >= 16;
       }
-
-      return true;
+      return false;
     };
 
     if (auto inits = op.getDpsInits();

--- a/test/mlir/unittests/Transforms/GPU/GpuUtilsTest.cpp
+++ b/test/mlir/unittests/Transforms/GPU/GpuUtilsTest.cpp
@@ -15,7 +15,8 @@
 TEST(testAdjustTiles, GputUtilsTest) {
   bool print = false;
   auto testAdjust = [print](int64_t totalSize, SmallVector<int64_t> &tiles,
-                            const SmallVector<int64_t> &expected) {
+                            const SmallVector<int64_t> &expected,
+                            bool xeGpu = false) {
     if (print) {
       std::cout << totalSize << ": [";
       for (unsigned i = 0; i < tiles.size(); i++) {
@@ -24,7 +25,7 @@ TEST(testAdjustTiles, GputUtilsTest) {
       std::cout << "] -> [";
     }
 
-    gc::adjustTiles(totalSize, tiles);
+    gc::adjustTiles(totalSize, tiles, xeGpu);
 
     if (print) {
       for (unsigned i = 0; i < tiles.size(); i++) {
@@ -36,15 +37,15 @@ TEST(testAdjustTiles, GputUtilsTest) {
     EXPECT_EQ(tiles, expected);
   };
   auto test = [testAdjust](int64_t totalSize, SmallVector<int64_t> tiles,
-                           SmallVector<int64_t> expected) {
+                           SmallVector<int64_t> expected, bool xeGpu = false) {
     if (tiles.size() != 2 || tiles[0] == tiles[1]) {
-      testAdjust(totalSize, tiles, expected);
+      testAdjust(totalSize, tiles, expected, xeGpu);
       return;
     }
     SmallVector<int64_t> reversed(tiles.rbegin(), tiles.rend());
-    testAdjust(totalSize, tiles, expected);
+    testAdjust(totalSize, tiles, expected, xeGpu);
     std::reverse(expected.begin(), expected.end());
-    testAdjust(totalSize, reversed, expected);
+    testAdjust(totalSize, reversed, expected, xeGpu);
   };
 
   test(8, {1, 1}, {1, 1});
@@ -91,4 +92,8 @@ TEST(testAdjustTiles, GputUtilsTest) {
   test(16384, {60, 128, 512}, {4, 32, 128});
   test(16384, {119, 256, 512}, {7, 32, 64});
   test(16384, {109, 256, 512}, {109, 8, 16});
+
+  test(16384, {8, 16, 32, 256, 512}, {1, 1, 1, 128, 128}, true);
+  test(16384, {8, 16, 32, 1024, 256}, {1, 1, 1, 256, 64}, true);
+  test(16384, {8, 16, 32, 16, 4096}, {1, 1, 1, 8, 2048}, true);
 }


### PR DESCRIPTION
When tiling for XeGPU, set all 1's for the leading tiles and adjust only the last two. It should allow for further squeezing.