### PR TITLE
[GpuOclRuntime] Add spirv dump option

### DIFF
--- a/include/gc/ExecutionEngine/GPURuntime/GpuOclRuntime.h
+++ b/include/gc/ExecutionEngine/GPURuntime/GpuOclRuntime.h
@@ -226,6 +226,7 @@ private:
 struct OclModuleBuilderOpts {
   StringRef funcName = {};
   bool printIr = false;
+  bool spirvDump = false;
   bool enableObjectDump = false;
   ArrayRef<StringRef> sharedLibPaths = {};
   void (*pipeline)(OpPassManager &) = nullptr;
@@ -254,6 +255,7 @@ struct OclModuleBuilder {
 private:
   ModuleOp mlirModule;
   const bool printIr;
+  const bool spirvDump;
   const bool enableObjectDump;
   const ArrayRef<StringRef> sharedLibPaths;
   void (*const pipeline)(OpPassManager &);

--- a/lib/gc/ExecutionEngine/GPURuntime/ocl/GpuOclRuntime.cpp
+++ b/lib/gc/ExecutionEngine/GPURuntime/ocl/GpuOclRuntime.cpp
@@ -128,9 +128,10 @@ struct Kernel {
 
   explicit Kernel(cl_program program, cl_kernel kernel, const size_t *gridSize,
                   const size_t *blockSize, size_t argNum, const size_t *argSize)
-      : program(program), kernel(kernel),
-        globalSize{gridSize[0] * blockSize[0], gridSize[1] * blockSize[1],
-                   gridSize[2] * blockSize[2]},
+      : program(program),
+        kernel(kernel), globalSize{gridSize[0] * blockSize[0],
+                                   gridSize[1] * blockSize[1],
+                                   gridSize[2] * blockSize[2]},
         localSize{blockSize[0], blockSize[1], blockSize[2]},
         argSize(argSize, argSize + argNum) {
 #ifndef NDEBUG

--- a/src/gc-gpu-runner/GpuRunner.cpp
+++ b/src/gc-gpu-runner/GpuRunner.cpp
@@ -61,6 +61,9 @@ struct Options {
       "print-ir",
       llvm::cl::desc("Print the resulting IR before the execution."),
       llvm::cl::init(false), llvm::cl::cat(runnerCategory)};
+  llvm::cl::opt<bool> dumpSpirv{
+      "dump-spirv", llvm::cl::desc("Dump spirv for generated kernels."),
+      llvm::cl::init(false), llvm::cl::cat(runnerCategory)};
   llvm::cl::opt<std::string> objDumpFile{
       "obj-dump-file",
       llvm::cl::desc("Dump the compiled object to the specified file."),
@@ -143,6 +146,7 @@ int main(int argc, char **argv) {
                                        opts.sharedLibs.end());
   builderOpts.funcName = opts.mainFuncName;
   builderOpts.printIr = opts.printIr;
+  builderOpts.spirvDump = opts.dumpSpirv;
   builderOpts.enableObjectDump = !opts.objDumpFile.getValue().empty();
   builderOpts.sharedLibPaths = sharedLibs;
   builderOpts.pipeline =


### PR DESCRIPTION
This should help with kernel debugging. Also, no need to rely on the driver's env variables we had problems with.